### PR TITLE
Fixed issue with no title and fixed the poster url

### DIFF
--- a/public/js/settings-netflix.js
+++ b/public/js/settings-netflix.js
@@ -400,7 +400,7 @@ function processNetflixData(netflixActivityItems) {
             row.classList.add('bg-warning')
         }
 
-        if (netflixActivityItem.tmdbMatch === null || netflixActivityItem.tmdbMatch.posterPath === null) {
+        if (netflixActivityItem.tmdbMatch === null || netflixActivityItem.tmdbMatch.poster_path === null) {
             tmdb_cover.src = '/images/placeholder-image.png';
             tmdb_link.innerText = 'Image not found on TMDB';
         } else {

--- a/src/Service/Netflix/NetflixActivityItemsConverter.php
+++ b/src/Service/Netflix/NetflixActivityItemsConverter.php
@@ -31,6 +31,10 @@ class NetflixActivityItemsConverter
     {
         $tmdbSearchResults = [];
         foreach ($activityItems as $activityItem) {
+            if(trim($activityItem->getTitle()) == '') {
+                $this->logger->debug('Netflix: Ignoring item because it has no valid title', ['netflixTitle' => $activityItem->getTitle()]);
+                continue;
+            }
             $mediaData = $this->extractMediaDataFromTitle($activityItem->getTitle());
 
             if ($mediaData['type'] !== 'movie') {


### PR DESCRIPTION
I found these two bugs
It's really supposed to be `poster_path` instead of `posterPath`, because `poster_path` is the key that is being returned by the TMDB API. So checking if `posterPath === null` will always return false, because `posterPath` simply does not exist.
This results into items without thumbnail.
Another weird thing that I experienced on my side, is that my Netflix Activity file sometimes literally contains rows with no title. In the CSV file it will say " ". 
So to catch this, I trimmed the title and checked if it was "" or not. Otherwise errors would be caught, which is annoying.