### PR TITLE
Disable the input fields during 'Not found' filter

### DIFF
--- a/public/js/settings-netflix.js
+++ b/public/js/settings-netflix.js
@@ -167,8 +167,10 @@ function updateTable() {
         return;
     }
 
-    document.querySelector('label[for="amountToShowInput"]').classList.remove('d-none');
-    document.getElementById('amountToShowInput').classList.remove('d-none');
+    
+    enable(document.querySelector('label[for="amountToShowInput"]'));
+    enable(document.getElementById('amountToShowInput'));
+    enable(document.getElementById('searchInput'));
     if (itemsPerPage === 'all') {
         createPageNavigation(rows.length, rows.length);
     } else {

--- a/public/js/settings-netflix.js
+++ b/public/js/settings-netflix.js
@@ -158,8 +158,9 @@ function updateTable() {
             }
         }
 
-        document.querySelector('label[for="amountToShowInput"]').classList.add('d-none');
-        document.getElementById('amountToShowInput').classList.add('d-none');
+        disable(document.querySelector('label[for="amountToShowInput"]'));
+        disable(document.getElementById('amountToShowInput'));
+        disable(document.getElementById('searchInput'));
         createPageNavigation(itemsPerPage, itemsPerPage, true);
         changePage('all');
 

--- a/public/js/settings-netflix.js
+++ b/public/js/settings-netflix.js
@@ -550,6 +550,12 @@ function saveTMDBItem() {
     let rowid = document.getElementById('tmdbSearchModal').dataset.rowid;
     let targetrow = document.getElementById(rowid);
 
+    if(targetrow.dataset.tmdbid === "undefined") {
+        targetrow.getElementsByTagName('b')[0].innerText = 'Description: ';
+        if(document.getElementById('selectFilterInput').value === "notfound") {
+            targetrow.classList.add('d-none');
+        }
+    }
     targetrow.getElementsByClassName('img-fluid')[0].src = checkedrow.getElementsByClassName('img-fluid')[0].src;
     targetrow.getElementsByClassName('img-fluid')[0].alt = checkedrow.getElementsByClassName('img-fluid')[0].alt;
     targetrow.getElementsByTagName('a')[0].href = checkedrow.getElementsByTagName('a')[0].href;


### PR DESCRIPTION
This disables the input fields instead of hiding them.