### PR TITLE
Bugfix: Disable unnecessary imagick extension

### DIFF
--- a/build/php/Dockerfile
+++ b/build/php/Dockerfile
@@ -1,14 +1,13 @@
 FROM webdevops/php-nginx:8.2-alpine AS development
-ENV WEB_DOCUMENT_ROOT="/app/public"
+ENV WEB_DOCUMENT_ROOT="/app/public" \
+    PHP_DISMOD=imagick
 RUN apk add --no-cache make nano
 USER application
 WORKDIR /app
 
 FROM development AS production
 ARG APPLICATION_VERSION
-ENV \ 
-    APPLICATION_VERSION=${APPLICATION_VERSION} \ 
-    PHP_DISMOD=imagick
+ENV APPLICATION_VERSION=${APPLICATION_VERSION}
 COPY --chown=application ./ ./
 COPY .env.production.example .env
 COPY settings/supervisor/movary.conf /opt/docker/etc/supervisor.d/movary.conf

--- a/build/php/Dockerfile
+++ b/build/php/Dockerfile
@@ -6,7 +6,9 @@ WORKDIR /app
 
 FROM development AS production
 ARG APPLICATION_VERSION
-ENV APPLICATION_VERSION=${APPLICATION_VERSION}
+ENV \ 
+    APPLICATION_VERSION=${APPLICATION_VERSION} \ 
+    PHP_DISMOD=imagick
 COPY --chown=application ./ ./
 COPY .env.production.example .env
 COPY settings/supervisor/movary.conf /opt/docker/etc/supervisor.d/movary.conf


### PR DESCRIPTION
By adding the environment variable `PHP_DISMOD` and setting it to 'imagick', the container won't install the imagick extension and the error should disappear.
At least, it disappeared on my machine.