### PR TITLE
Added docker secrets support

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -118,14 +118,6 @@ volumes:
 ```yaml
 version: "3.5"
 
-secrets:
-  mysql_root_password:
-    file: /path/to/docker/secret/mysql_root_password_file
-  mysql_password:
-    file: /path/to/docker/secret/mysql_password_file
-  tmdb_key:
-    file: /path/to/docker/secret/tmdb_key_file
-
 services:
   movary:
     image: leepeuker/movary:latest
@@ -142,6 +134,7 @@ services:
     volumes:
       - movary-storage:/app/storage
     secrets:
+      - tmdb_key
       - mysql_password
 
   mysql:
@@ -156,6 +149,14 @@ services:
     secrets:
       - mysql_root_password
       - mysql_password
+
+secrets:
+  mysql_root_password:
+    file: /path/to/docker/secret/mysql_root_password
+  mysql_password:
+    file: /path/to/docker/secret/mysql_password
+  tmdb_key:
+    file: /path/to/docker/secret/tmdb_key
 
 volumes:
   movary-db:

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -31,10 +31,18 @@ The easiest way to do this are managed docker volumes (used in the examples belo
     If you bind a local mount, make sure the directory exists before you start the container
     and that it has the necessary permissions/ownership.
 
+## Docker secrets
+
+Docker secrets can be used for all environment variables, just append `_FILE` to the environment variable name.
+Secrets are used as a fallback for not existing environment variables.
+Make sure to not set the environment variable without the `_FILE` prefix if you want to use a secret.
+
+For more info on Docker secrets, read the [official Docker documentation](https://docs.docker.com/engine/swarm/secrets/).
+
 ## Examples
 
 All examples include the environment variable `TMDB_API_KEY` (get a key [here](https://www.themoviedb.org/settings/api)).
-It is not strictly required to be set here but recommend. 
+It is not strictly required to be set here but recommend.
 Many features of the application will not work correctly without it.
 
 ### With SQLite
@@ -69,9 +77,7 @@ $ docker run --rm -d \
   leepeuker/movary:latest
 ```
 
-### With docker compose
-
-Here is a `docker-compose.yml` template
+### docker-compose.yml with MySQL
 
 ```yaml
 version: "3.5"
@@ -107,15 +113,7 @@ volumes:
   movary-storage:
 ```
 
-### With Docker secrets
-
-The following environment variable can also be added with secrets.
-
-* `DATABASE_MYSQL_PASSWORD` 
-* `DATABASE_MYSQL_ROOT_PASSWORD`
-
-Both can be injected as secrets instead of plain environment variables by appending `_FILE` (with one underscore) to them.
-A `docker-compose.yml` file would look like this:
+### docker-compose.yml with MySQL and secrets
 
 ```yaml
 version: "3.5"
@@ -125,6 +123,8 @@ secrets:
     file: /path/to/docker/secret/mysql_root_password_file
   mysql_password:
     file: /path/to/docker/secret/mysql_password_file
+  tmdb_key:
+    file: /path/to/docker/secret/tmdb_key_file
 
 services:
   movary:
@@ -133,7 +133,7 @@ services:
     ports:
       - "80:80"
     environment:
-      TMDB_API_KEY: "<tmdb_key>"
+      TMDB_API_KEY_FILE: /run/secrets/tmdb_key
       DATABASE_MODE: "mysql"
       DATABASE_MYSQL_HOST: "mysql"
       DATABASE_MYSQL_NAME: "movary"
@@ -161,7 +161,3 @@ volumes:
   movary-db:
   movary-storage:
 ```
-
-If both `DATABASE_MYSQL_PASSWORD` and `DATABASE_MYSQL_PASSWORD_FILE` are present in the Movary docker container, the `DATABASE_MYSQL_PASSWORD` will have priority and will be used instead of the `DATABASE_MYSQL_PASSWORD_FILE`. So make sure you remove `DATABASE_MYSQL_PASSWORD` before using `DATABASE_MYSQL_PASSWORD_FILE`.
-
-For more info on Docker secrets, read the [official Docker documentation](https://docs.docker.com/engine/swarm/secrets/)

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -35,7 +35,7 @@ The easiest way to do this are managed docker volumes (used in the examples belo
 
 Docker secrets can be used for all environment variables, just append `_FILE` to the environment variable name.
 Secrets are used as a fallback for not existing environment variables.
-Make sure to not set the environment variable without the `_FILE` prefix if you want to use a secret.
+Make sure to not set the environment variable without the `_FILE` suffix if you want to use a secret.
 
 For more info on Docker secrets, read the [official Docker documentation](https://docs.docker.com/engine/swarm/secrets/).
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -112,7 +112,7 @@ volumes:
 The following environment variable can also be added with secrets.
 
 * `DATABASE_MYSQL_PASSWORD` 
-* `DATABASE_MYSQL_ROOT__PASSWORD`
+* `DATABASE_MYSQL_ROOT_PASSWORD`
 
 Both can be injected as secrets instead of plain environment variables by appending `_FILE` (with one underscore) to them.
 A `docker-compose.yml` file would look like this:

--- a/settings/phinx.php
+++ b/settings/phinx.php
@@ -5,6 +5,12 @@ $container = require(__DIR__ . '/../bootstrap.php');
 
 $config = $container->get(Movary\ValueObject\Config::class);
 
+try {
+    $mysqlPassword = $config->getAsString('DATABASE_MYSQL_PASSWORD');
+} catch(OutOfBoundsException) {
+    $mysqlPassword = $config->getSecretAsString('DATABASE_MYSQL_PASSWORD__FILE');
+}
+
 $databaseMode = \Movary\Factory::getDatabaseMode($config);
 if ($databaseMode === 'sqlite') {
     $sqliteFile = pathinfo($config->getAsString('DATABASE_SQLITE'));
@@ -20,7 +26,7 @@ if ($databaseMode === 'sqlite') {
         'port' => \Movary\Factory::getDatabaseMysqlPort($config),
         'name' => $config->getAsString('DATABASE_MYSQL_NAME'),
         'user' => $config->getAsString('DATABASE_MYSQL_USER'),
-        'pass' => $config->getAsString('DATABASE_MYSQL_PASSWORD'),
+        'pass' => $mysqlPassword,
         'charset' => \Movary\Factory::getDatabaseMysqlCharset($config),
         'collation' => 'utf8_unicode_ci',
     ];

--- a/settings/phinx.php
+++ b/settings/phinx.php
@@ -5,8 +5,6 @@ $container = require(__DIR__ . '/../bootstrap.php');
 
 $config = $container->get(Movary\ValueObject\Config::class);
 
-$mysqlPassword = $config->getAsString('DATABASE_MYSQL_PASSWORD');
-
 $databaseMode = \Movary\Factory::getDatabaseMode($config);
 if ($databaseMode === 'sqlite') {
     $sqliteFile = pathinfo($config->getAsString('DATABASE_SQLITE'));
@@ -22,7 +20,7 @@ if ($databaseMode === 'sqlite') {
         'port' => \Movary\Factory::getDatabaseMysqlPort($config),
         'name' => $config->getAsString('DATABASE_MYSQL_NAME'),
         'user' => $config->getAsString('DATABASE_MYSQL_USER'),
-        'pass' => $mysqlPassword,
+        'pass' => $config->getAsString('DATABASE_MYSQL_PASSWORD'),
         'charset' => \Movary\Factory::getDatabaseMysqlCharset($config),
         'collation' => 'utf8_unicode_ci',
     ];

--- a/settings/phinx.php
+++ b/settings/phinx.php
@@ -8,7 +8,7 @@ $config = $container->get(Movary\ValueObject\Config::class);
 try {
     $mysqlPassword = $config->getAsString('DATABASE_MYSQL_PASSWORD');
 } catch(OutOfBoundsException) {
-    $mysqlPassword = $config->getSecretAsString('DATABASE_MYSQL_PASSWORD__FILE');
+    $mysqlPassword = $config->getSecretAsString('DATABASE_MYSQL_PASSWORD_FILE');
 }
 
 $databaseMode = \Movary\Factory::getDatabaseMode($config);

--- a/settings/phinx.php
+++ b/settings/phinx.php
@@ -5,11 +5,7 @@ $container = require(__DIR__ . '/../bootstrap.php');
 
 $config = $container->get(Movary\ValueObject\Config::class);
 
-try {
-    $mysqlPassword = $config->getAsString('DATABASE_MYSQL_PASSWORD');
-} catch(OutOfBoundsException) {
-    $mysqlPassword = $config->getSecretAsString('DATABASE_MYSQL_PASSWORD_FILE');
-}
+$mysqlPassword = $config->getAsString('DATABASE_MYSQL_PASSWORD');
 
 $databaseMode = \Movary\Factory::getDatabaseMode($config);
 if ($databaseMode === 'sqlite') {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -40,7 +40,6 @@ use Movary\Util\SessionWrapper;
 use Movary\ValueObject\Config;
 use Movary\ValueObject\DateFormat;
 use Movary\ValueObject\Http\Request;
-use OutOfBoundsException;
 use Phinx\Console\PhinxApplication;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Client\ClientInterface;
@@ -68,12 +67,18 @@ class Factory
 
     private const DEFAULT_ENABLE_FILE_LOGGING = true;
 
-    public static function createConfig() : Config
+    public static function createConfig(ContainerInterface $container) : Config
     {
         $dotenv = Dotenv::createMutable(self::createDirectoryAppRoot());
         $dotenv->safeLoad();
 
-        return Config::createFromEnv();
+        $fpmEnvironment = $_ENV;
+        $systemEnvironment = getenv();
+
+        return new Config(
+            $container->get(File::class),
+            array_merge($fpmEnvironment, $systemEnvironment)
+        );
     }
 
     public static function createCreatePublicStorageLink(ContainerInterface $container) : CreatePublicStorageLink
@@ -128,11 +133,7 @@ class Factory
     public static function createDbConnection(Config $config) : DBAL\Connection
     {
         $databaseMode = self::getDatabaseMode($config);
-        try {
-            $mysqlPassword = $config->getAsString('DATABASE_MYSQL_PASSWORD');
-        } catch(OutOfBoundsException) {
-            $mysqlPassword = $config->getSecretAsString('DATABASE_MYSQL_PASSWORD_FILE');
-        }
+        $mysqlPassword = $config->getAsString('DATABASE_MYSQL_PASSWORD');
 
         $config = match ($databaseMode) {
             'sqlite' => [
@@ -220,11 +221,7 @@ class Factory
     {
         $formatter = new LineFormatter(LineFormatter::SIMPLE_FORMAT, LineFormatter::SIMPLE_DATE);
 
-        try {
-            $enableStackTrace = $config->getAsBool('LOG_ENABLE_STACKTRACE');
-        } catch (OutOfBoundsException) {
-            $enableStackTrace = self::DEFAULT_LOG_ENABLE_STACKTRACE;
-        }
+        $enableStackTrace = $config->getAsBool('LOG_ENABLE_STACKTRACE', self::DEFAULT_LOG_ENABLE_STACKTRACE);
 
         $formatter->includeStacktraces($enableStackTrace);
 
@@ -237,11 +234,7 @@ class Factory
 
         $logger->pushHandler(self::createLoggerStreamHandlerStdout($container, $config));
 
-        try {
-            $enableFileLogging = $config->getAsBool('LOG_ENABLE_FILE_LOGGING');
-        } catch (OutOfBoundsException) {
-            $enableFileLogging = self::DEFAULT_ENABLE_FILE_LOGGING;
-        }
+        $enableFileLogging = $config->getAsBool('LOG_ENABLE_FILE_LOGGING', self::DEFAULT_ENABLE_FILE_LOGGING);
 
         if ($enableFileLogging === true) {
             $logger->pushHandler(self::createLoggerStreamHandlerFile($container, $config));
@@ -390,11 +383,7 @@ class Factory
 
     private static function getApplicationVersion(Config $config) : string
     {
-        try {
-            return $config->getAsString('APPLICATION_VERSION');
-        } catch (OutOfBoundsException) {
-            return self::DEFAULT_APPLICATION_VERSION;
-        }
+        return $config->getAsString('APPLICATION_VERSION', self::DEFAULT_APPLICATION_VERSION);
     }
 
     private static function getLogLevel(Config $config) : string

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -63,7 +63,9 @@ class Factory
         $dotenv = Dotenv::createMutable(self::createDirectoryAppRoot());
         $dotenv->safeLoad();
 
-        return Config::createFromEnv();
+        $secretEnv = Config::getSecrets();
+
+        return Config::createFromEnv($secretEnv);
     }
 
     public static function createCreatePublicStorageLink(ContainerInterface $container) : CreatePublicStorageLink

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -133,7 +133,6 @@ class Factory
     public static function createDbConnection(Config $config) : DBAL\Connection
     {
         $databaseMode = self::getDatabaseMode($config);
-        $mysqlPassword = $config->getAsString('DATABASE_MYSQL_PASSWORD');
 
         $config = match ($databaseMode) {
             'sqlite' => [
@@ -146,7 +145,7 @@ class Factory
                 'port' => self::getDatabaseMysqlPort($config),
                 'dbname' => $config->getAsString('DATABASE_MYSQL_NAME'),
                 'user' => $config->getAsString('DATABASE_MYSQL_USER'),
-                'password' => $mysqlPassword,
+                'password' => $config->getAsString('DATABASE_MYSQL_PASSWORD'),
                 'charset' => self::getDatabaseMysqlCharset($config),
             ],
             default => throw new \RuntimeException('Not supported database mode: ' . $databaseMode)

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -131,7 +131,7 @@ class Factory
         try {
             $mysqlPassword = $config->getAsString('DATABASE_MYSQL_PASSWORD');
         } catch(OutOfBoundsException) {
-            $mysqlPassword = $config->getSecretAsString('DATABASE_MYSQL_PASSWORD__FILE');
+            $mysqlPassword = $config->getSecretAsString('DATABASE_MYSQL_PASSWORD_FILE');
         }
 
         $config = match ($databaseMode) {

--- a/src/Service/ServerSettings.php
+++ b/src/Service/ServerSettings.php
@@ -4,6 +4,7 @@ namespace Movary\Service;
 
 use Doctrine\DBAL\Connection;
 use Movary\ValueObject\Config;
+use Movary\ValueObject\Exception\ConfigKeyNotSetException;
 
 class ServerSettings
 {
@@ -49,7 +50,7 @@ class ServerSettings
     {
         try {
             $tmdbApiKey = $this->config->getAsString('APPLICATION_URL');
-        } catch (\RuntimeException) {
+        } catch (ConfigKeyNotSetException) {
             return false;
         }
 
@@ -60,7 +61,7 @@ class ServerSettings
     {
         try {
             $tmdbApiKey = $this->config->getAsString('TMDB_API_KEY');
-        } catch (\RuntimeException) {
+        } catch (ConfigKeyNotSetException) {
             return false;
         }
 

--- a/src/Service/ServerSettings.php
+++ b/src/Service/ServerSettings.php
@@ -49,7 +49,7 @@ class ServerSettings
     {
         try {
             $tmdbApiKey = $this->config->getAsString('APPLICATION_URL');
-        } catch (\OutOfBoundsException) {
+        } catch (\RuntimeException) {
             return false;
         }
 
@@ -60,7 +60,7 @@ class ServerSettings
     {
         try {
             $tmdbApiKey = $this->config->getAsString('TMDB_API_KEY');
-        } catch (\OutOfBoundsException) {
+        } catch (\RuntimeException) {
             return false;
         }
 

--- a/src/ValueObject/Config.php
+++ b/src/ValueObject/Config.php
@@ -2,7 +2,9 @@
 
 namespace Movary\ValueObject;
 
+use Exception;
 use OutOfBoundsException;
+use TypeError;
 
 class Config
 {
@@ -16,6 +18,24 @@ class Config
         $systemEnvironment = getenv();
 
         return new self(array_merge($fpmEnvironment, $systemEnvironment, $additionalData));
+    }
+
+    public static function getSecrets() : array
+    {
+        try {
+            $secrets = [];
+            $mysqlRootPassword = file_get_contents($_ENV['DATABASE_MYSQL_ROOT_PASSWORD_FILE']);
+            $mysqlPassword = file_get_contents($_ENV['DATABASE_MYSQL_PASSWORD_FILE']);
+            if($mysqlPassword !== false) {
+                array_push($secrets, ['DATABASE_MYSQL_PASSWORD' => rtrim($mysqlPassword)]);
+            }
+            if($mysqlRootPassword !== false) {
+                array_push($secrets, ['DATABASE_MYSQL_ROOT_PASSWORD' => rtrim($mysqlRootPassword)]);
+            }
+            return $secrets;
+        } catch(TypeError) {
+            return [];
+        }
     }
 
     public function getAsBool(string $parameter, ?bool $fallbackValue = null) : bool

--- a/src/ValueObject/Config.php
+++ b/src/ValueObject/Config.php
@@ -61,7 +61,7 @@ class Config
             $secretFile = $this->get($key . '_FILE');
 
             if ($this->fileUtil->fileExists($secretFile) === true) {
-                return $this->fileUtil->readFile($secretFile);
+                return trim($this->fileUtil->readFile($secretFile));
             }
         }
 

--- a/src/ValueObject/Config.php
+++ b/src/ValueObject/Config.php
@@ -15,9 +15,6 @@ class Config
     {
         $fpmEnvironment = $_ENV;
         $systemEnvironment = getenv();
-        // $mysqlRootPassword = file_get_contents($fpmEnvironment['DATABASE_MYSQL_ROOT_PASSWORD_FILE']);
-        // $mysqlPassword = file_get_contents($fpmEnvironment['DATABASE_MYSQL_PASSWORD_FILE']);
-        // array_push($additionalData, [''])
 
         return new self(array_merge($fpmEnvironment, $systemEnvironment, $additionalData));
     }

--- a/src/ValueObject/Config.php
+++ b/src/ValueObject/Config.php
@@ -3,6 +3,7 @@
 namespace Movary\ValueObject;
 
 use Movary\Util\File;
+use Movary\ValueObject\Exception\ConfigKeyNotSetException;
 
 class Config
 {
@@ -12,11 +13,12 @@ class Config
     ) {
     }
 
-    public function getAsBool(string $parameter, ?bool $fallbackValue = null) : bool
+    /** @throws ConfigKeyNotSetException */
+    public function getAsBool(string $key, ?bool $fallbackValue = null) : bool
     {
         try {
-            return (bool)$this->get($parameter);
-        } catch (\RuntimeException $e) {
+            return (bool)$this->get($key);
+        } catch (ConfigKeyNotSetException $e) {
             if ($fallbackValue === null) {
                 throw $e;
             }
@@ -25,11 +27,12 @@ class Config
         }
     }
 
-    public function getAsInt(string $parameter, ?int $fallbackValue = null) : int
+    /** @throws ConfigKeyNotSetException */
+    public function getAsInt(string $key, ?int $fallbackValue = null) : int
     {
         try {
-            return (int)$this->get($parameter);
-        } catch (\RuntimeException $e) {
+            return (int)$this->get($key);
+        } catch (ConfigKeyNotSetException $e) {
             if ($fallbackValue === null) {
                 throw $e;
             }
@@ -38,11 +41,12 @@ class Config
         }
     }
 
-    public function getAsString(string $parameter, ?string $fallbackValue = null) : string
+    /** @throws ConfigKeyNotSetException */
+    public function getAsString(string $key, ?string $fallbackValue = null) : string
     {
         try {
-            return (string)$this->get($parameter);
-        } catch (\RuntimeException $e) {
+            return (string)$this->get($key);
+        } catch (ConfigKeyNotSetException $e) {
             if ($fallbackValue === null) {
                 throw $e;
             }
@@ -51,6 +55,7 @@ class Config
         }
     }
 
+    /** @throws ConfigKeyNotSetException */
     private function get(string $key) : mixed
     {
         if (isset($this->config[$key]) === true) {
@@ -65,6 +70,6 @@ class Config
             }
         }
 
-        throw new \RuntimeException('Config key does not exist: ' . $key);
+        throw ConfigKeyNotSetException::create($key);
     }
 }

--- a/src/ValueObject/Config.php
+++ b/src/ValueObject/Config.php
@@ -15,26 +15,11 @@ class Config
     {
         $fpmEnvironment = $_ENV;
         $systemEnvironment = getenv();
+        // $mysqlRootPassword = file_get_contents($fpmEnvironment['DATABASE_MYSQL_ROOT_PASSWORD_FILE']);
+        // $mysqlPassword = file_get_contents($fpmEnvironment['DATABASE_MYSQL_PASSWORD_FILE']);
+        // array_push($additionalData, [''])
 
         return new self(array_merge($fpmEnvironment, $systemEnvironment, $additionalData));
-    }
-
-    public static function getSecrets() : array
-    {
-        try {
-            $secrets = [];
-            $mysqlRootPassword = file_get_contents($_ENV['DATABASE_MYSQL_ROOT_PASSWORD_FILE']);
-            $mysqlPassword = file_get_contents($_ENV['DATABASE_MYSQL_PASSWORD_FILE']);
-            if($mysqlPassword !== false) {
-                array_push($secrets, ['DATABASE_MYSQL_PASSWORD' => rtrim($mysqlPassword)]);
-            }
-            if($mysqlRootPassword !== false) {
-                array_push($secrets, ['DATABASE_MYSQL_ROOT_PASSWORD' => rtrim($mysqlRootPassword)]);
-            }
-            return $secrets;
-        } catch(TypeError) {
-            return [];
-        }
     }
 
     public function getAsBool(string $parameter, ?bool $fallbackValue = null) : bool
@@ -67,6 +52,22 @@ class Config
     {
         try {
             return (string)$this->get($parameter);
+        } catch (OutOfBoundsException $e) {
+            if ($fallbackValue === null) {
+                throw $e;
+            }
+
+            return $fallbackValue;
+        }
+    }
+
+    public function getSecretAsString(string $parameter, ?string $fallbackValue = null) : string
+    {
+        try {
+            if(file_exists($this->get($parameter))) {
+                return (string)file_get_contents($this->get($parameter));
+            }
+            return $fallbackValue;
         } catch (OutOfBoundsException $e) {
             if ($fallbackValue === null) {
                 throw $e;

--- a/src/ValueObject/Config.php
+++ b/src/ValueObject/Config.php
@@ -2,7 +2,6 @@
 
 namespace Movary\ValueObject;
 
-use Exception;
 use OutOfBoundsException;
 use TypeError;
 

--- a/src/ValueObject/Exception/ConfigKeyNotSetException.php
+++ b/src/ValueObject/Exception/ConfigKeyNotSetException.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Movary\ValueObject\Exception;
+
+class ConfigKeyNotSetException extends \RuntimeException
+{
+    public static function create(string $key) : self
+    {
+        return new self('Config key does not exist: ' . $key);
+    }
+}

--- a/tests/unit/ValueObject/ConfigTest.php
+++ b/tests/unit/ValueObject/ConfigTest.php
@@ -2,19 +2,27 @@
 
 namespace Tests\Unit\Movary\ValueObject;
 
+use Movary\Util\File;
 use Movary\ValueObject\Config;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /** @covers \Movary\ValueObject\Config */
 class ConfigTest extends TestCase
 {
+    private File|MockObject $fileUtilMock;
+
     private Config $subject;
 
     public function setUp() : void
     {
-        $this->subject = Config::createFromEnv(
+        $this->fileUtilMock = $this->createMock(File::class);
+
+        $this->subject = new Config(
+            $this->fileUtilMock,
             [
                 'string_test' => 'value',
+                'string_test_secret_FILE' => '/path/to/secret',
                 'int_test' => 2,
                 'bool_test' => true,
             ],
@@ -25,9 +33,14 @@ class ConfigTest extends TestCase
     {
         self::assertSame(true, $this->subject->getAsBool('bool_test'));
         self::assertSame(false, $this->subject->getAsBool('bool_test_not_existing', false));
+    }
 
-        $this->expectException(\OutOfBoundsException::class);
-        $this->expectExceptionMessage('Key does not exist: bool_test_not_existing');
+    public function testGetAsBoolThrowsExceptionWhenOnMissingValueAndFallback() : void
+    {
+        $this->fileUtilMock->expects(self::never())->method('fileExists');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Config key does not exist: bool_test_not_existing');
         $this->subject->getAsBool('bool_test_not_existing');
     }
 
@@ -35,9 +48,14 @@ class ConfigTest extends TestCase
     {
         self::assertSame(2, $this->subject->getAsInt('int_test'));
         self::assertSame(3, $this->subject->getAsInt('int_test_not_existing', 3));
+    }
 
-        $this->expectException(\OutOfBoundsException::class);
-        $this->expectExceptionMessage('Key does not exist: int_test_not_existing');
+    public function testGetAsIntThrowsExceptionWhenOnMissingValueAndFallback() : void
+    {
+        $this->fileUtilMock->expects(self::never())->method('fileExists');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Config key does not exist: int_test_not_existing');
         $this->subject->getAsBool('int_test_not_existing');
     }
 
@@ -45,9 +63,47 @@ class ConfigTest extends TestCase
     {
         self::assertSame('value', $this->subject->getAsString('string_test'));
         self::assertSame('fallback', $this->subject->getAsString('string_test_not_existing', 'fallback'));
+    }
 
-        $this->expectException(\OutOfBoundsException::class);
-        $this->expectExceptionMessage('Key does not exist: string_test_not_existing');
-        $this->subject->getAsBool('string_test_not_existing');
+    public function testGetAsStringReturnsSecretAsFirstFallback() : void
+    {
+        $this->fileUtilMock
+            ->expects(self::once())
+            ->method('fileExists')
+            ->with('/path/to/secret')
+            ->willReturn(true);
+
+        $this->fileUtilMock
+            ->expects(self::once())
+            ->method('readFile')
+            ->with('/path/to/secret')
+            ->willReturn('value_secret');
+
+        self::assertSame('value_secret', $this->subject->getAsString('string_test_secret'));
+    }
+
+    public function testGetAsStringThrowsExceptionWhenOnMissingValueAndSecretFileAndFallback() : void
+    {
+        $this->fileUtilMock
+            ->expects(self::once())
+            ->method('fileExists')
+            ->with('/path/to/secret')
+            ->willReturn(false);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Config key does not exist: string_test_secret');
+
+        self::assertSame('value_secret', $this->subject->getAsString('string_test_secret'));
+    }
+
+
+
+    public function testGetAsStringThrowsExceptionWhenOnMissingValueAndFallback() : void
+    {
+        $this->fileUtilMock->expects(self::never())->method('fileExists');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Config key does not exist: string_test_not_existing');
+        $this->subject->getAsString('string_test_not_existing');
     }
 }

--- a/tests/unit/ValueObject/ConfigTest.php
+++ b/tests/unit/ValueObject/ConfigTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Movary\ValueObject;
 
 use Movary\Util\File;
 use Movary\ValueObject\Config;
+use Movary\ValueObject\Exception\ConfigKeyNotSetException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -39,8 +40,9 @@ class ConfigTest extends TestCase
     {
         $this->fileUtilMock->expects(self::never())->method('fileExists');
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(ConfigKeyNotSetException::class);
         $this->expectExceptionMessage('Config key does not exist: bool_test_not_existing');
+
         $this->subject->getAsBool('bool_test_not_existing');
     }
 
@@ -54,8 +56,9 @@ class ConfigTest extends TestCase
     {
         $this->fileUtilMock->expects(self::never())->method('fileExists');
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(ConfigKeyNotSetException::class);
         $this->expectExceptionMessage('Config key does not exist: int_test_not_existing');
+
         $this->subject->getAsBool('int_test_not_existing');
     }
 
@@ -82,6 +85,16 @@ class ConfigTest extends TestCase
         self::assertSame('value_secret', $this->subject->getAsString('string_test_secret'));
     }
 
+    public function testGetAsStringThrowsExceptionWhenOnMissingValueAndFallback() : void
+    {
+        $this->fileUtilMock->expects(self::never())->method('fileExists');
+
+        $this->expectException(ConfigKeyNotSetException::class);
+        $this->expectExceptionMessage('Config key does not exist: string_test_not_existing');
+
+        $this->subject->getAsString('string_test_not_existing');
+    }
+
     public function testGetAsStringThrowsExceptionWhenOnMissingValueAndSecretFileAndFallback() : void
     {
         $this->fileUtilMock
@@ -90,20 +103,9 @@ class ConfigTest extends TestCase
             ->with('/path/to/secret')
             ->willReturn(false);
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(ConfigKeyNotSetException::class);
         $this->expectExceptionMessage('Config key does not exist: string_test_secret');
 
         self::assertSame('value_secret', $this->subject->getAsString('string_test_secret'));
-    }
-
-
-
-    public function testGetAsStringThrowsExceptionWhenOnMissingValueAndFallback() : void
-    {
-        $this->fileUtilMock->expects(self::never())->method('fileExists');
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Config key does not exist: string_test_not_existing');
-        $this->subject->getAsString('string_test_not_existing');
     }
 }


### PR DESCRIPTION
I've added Docker secret support for two variables:

* DATABASE_MYSQL_PASSWORD
* DATABASE_MYSQL_ROOT_PASSWORD

It should work in theory, but haven't tested it yet, because I don't like using Docker on Windows 10, and I especially dislike having to debug applications in a docker environment.