### PR TITLE
Save sorting options using cookies

### DIFF
--- a/src/HttpController/ActorsController.php
+++ b/src/HttpController/ActorsController.php
@@ -44,6 +44,9 @@ class ActorsController
         $actorsCount = $this->movieHistoryApi->fetchMostWatchedActorsCount($userId, $requestData->getSearchTerm(), $requestData->getGender());
         $paginationElements = $this->paginationElementsCalculator->createPaginationElements($actorsCount, $requestData->getLimit(), $requestData->getPage());
 
+	setcookie("person-sort-by", $requestData->getSortBy(), time() + 60 * 60 * 24 * 365, "/");
+	setcookie("person-sort-order", (string)$requestData->getSortOrder(), time() + 60 * 60 * 24 * 365, "/");
+
         return Response::create(
             StatusCode::createOk(),
             $this->twig->render('page/actors.html.twig', [

--- a/src/HttpController/DirectorsController.php
+++ b/src/HttpController/DirectorsController.php
@@ -44,6 +44,9 @@ class DirectorsController
         $directorsCount = $this->movieHistoryApi->fetchDirectorsCount($userId, $requestData->getSearchTerm(), $requestData->getGender());
         $paginationElements = $this->paginationElementsCalculator->createPaginationElements($directorsCount, $requestData->getLimit(), $requestData->getPage());
 
+	setcookie("person-sort-by", $requestData->getSortBy(), time() + 60 * 60 * 24 * 365, "/");
+	setcookie("person-sort-order", (string)$requestData->getSortOrder(), time() + 60 * 60 * 24 * 365, "/");
+
         return Response::create(
             StatusCode::createOk(),
             $this->twig->render('page/directors.html.twig', [

--- a/src/HttpController/Mapper/MoviesRequestMapper.php
+++ b/src/HttpController/Mapper/MoviesRequestMapper.php
@@ -29,10 +29,12 @@ class MoviesRequestMapper
 
         $getParameters = $request->getGetParameters();
 
+	$_sortBy = isset($_COOKIE['movie-sort-by']) ? $_COOKIE['movie-sort-by'] : self::DEFAULT_SORT_BY;
+
         $searchTerm = $getParameters['s'] ?? null;
         $page = $getParameters['p'] ?? 1;
-        $limit = $getParameters['pp'] ?? self::DEFAULT_LIMIT;
-        $sortBy = $getParameters['sb'] ?? self::DEFAULT_SORT_BY;
+	$limit = $getParameters['pp'] ?? self::DEFAULT_LIMIT;
+        $sortBy = $getParameters['sb'] ?? $_sortBy;
         $sortOrder = $this->mapSortOrder($getParameters);
         $releaseYear = $getParameters['ry'] ?? self::DEFAULT_RELEASE_YEAR;
         $releaseYear = empty($releaseYear) === false ? Year::createFromString($releaseYear) : null;
@@ -55,7 +57,9 @@ class MoviesRequestMapper
     private function mapSortOrder(array $getParameters) : SortOrder
     {
         if (isset($getParameters['so']) === false) {
-            return SortOrder::createAsc();
+	    if (!isset($_COOKIE['movie-sort-order'])) return SortOrder::createAsc();
+	    else if ($_COOKIE['movie-sort-order'] == 'desc') return SortOrder::createDesc();
+	    else return SortOrder::createAsc();
         }
 
         return match ($getParameters['so']) {

--- a/src/HttpController/Mapper/PersonsRequestMapper.php
+++ b/src/HttpController/Mapper/PersonsRequestMapper.php
@@ -25,10 +25,12 @@ class PersonsRequestMapper
 
         $getParameters = $request->getGetParameters();
 
+	$_sortBy = isset($_COOKIE['person-sort-by']) ? $_COOKIE['person-sort-by'] : self::DEFAULT_SORT_BY;
+
         $searchTerm = $getParameters['s'] ?? null;
         $page = $getParameters['p'] ?? 1;
         $limit = $getParameters['pp'] ?? self::DEFAULT_LIMIT;
-        $sortBy = $getParameters['sb'] ?? self::DEFAULT_SORT_BY;
+        $sortBy = $getParameters['sb'] ?? $_sortBy;
         $sortOrder = $this->mapSortOrder($getParameters);
         $gender = isset($getParameters['ge']) === false || $getParameters['ge'] === '' ? null : Gender::createFromInt((int)$getParameters['ge']);
 
@@ -46,7 +48,9 @@ class PersonsRequestMapper
     private function mapSortOrder(array $getParameters) : SortOrder
     {
         if (isset($getParameters['so']) === false) {
-            return SortOrder::createDesc();
+	    if (!isset($_COOKIE['person-sort-order'])) return SortOrder::createAsc();
+	    else if ($_COOKIE['person-sort-order'] == 'desc') return SortOrder::createDesc();
+	    else return SortOrder::createAsc();
         }
 
         return match ($getParameters['so']) {

--- a/src/HttpController/MoviesController.php
+++ b/src/HttpController/MoviesController.php
@@ -57,6 +57,9 @@ class MoviesController
         );
         $paginationElements = $this->paginationElementsCalculator->createPaginationElements($historyCount, $requestData->getLimit(), $requestData->getPage());
 
+	setcookie('movie-sort-by', $requestData->getSortBy(), time() + 60 * 60 * 24 * 365, "/");
+	setcookie('movie-sort-order', (string)$requestData->getSortOrder(), time() + 60 * 60 * 24 * 365, "/");
+
         return Response::create(
             StatusCode::createOk(),
             $this->twig->render('page/movies.html.twig', [


### PR DESCRIPTION
use cookies to save sorting options for movies and people.

the cookies are set to last 1 year and are based in "/", here's what an example looks like:

'movie-sort-order' = 'desc'
'movie-sort-by' = 'name'
'person-sort-order' = 'asc'
'person-sort-by' = 'uniqueAppearances'


closes #441 