### PR TITLE
Add API endpoint for retreiving an auth token

### DIFF
--- a/db/migrations/mysql/20240126110011_add_device_name_to_auth_token_table.php
+++ b/db/migrations/mysql/20240126110011_add_device_name_to_auth_token_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddDeviceNameToAuthTokenTable extends AbstractMigration
+{
+    public function down() : void
+    {
+        $this->execute(
+            <<<SQL
+            ALTER TABLE `user_auth_token` DROP COLUMN device_name;
+            ALTER TABLE `user_auth_token` DROP COLUMN user_agent_string;
+            SQL,
+        );
+    }
+
+    public function up() : void
+    {
+        $this->execute(
+            <<<SQL
+            ALTER TABLE `user_auth_token` ADD COLUMN device_name VARCHAR(256);
+            ALTER TABLE `user_auth_token` ADD COLUMN user_agent_string VARCHAR(256);
+            SQL,
+        );
+    }
+}

--- a/db/migrations/sqlite/20240126110433_add_device_name_to_auth_token_table.php
+++ b/db/migrations/sqlite/20240126110433_add_device_name_to_auth_token_table.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddDeviceNameToAuthTokenTable extends AbstractMigration
+{
+    public function down() : void
+    {
+        $this->execute(
+            <<<SQL
+            CREATE TABLE `user_api_token_old` (
+                `user_id` INT(10) NOT NULL,
+                `token` CHAR(36) NOT NULL,
+                `created_at` TEXT NOT NULL,
+                PRIMARY KEY (`token`),
+                UNIQUE (`user_id`),
+                FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE CASCADE
+            )
+            SQL,
+        );
+        $this->execute('INSERT INTO `user_api_token_old` (`user_id`, `token`, `created_at`) SELECT `user_id`, `token`, `created_at` FROM `user_api_token`');
+        $this->execute('DROP TABLE `user_api_token`');
+        $this->execute('ALTER TABLE `user_api_token_old` RENAME TO `user_api_token`');
+    }
+
+    public function up() : void
+    {
+        $this->execute(
+            <<<SQL
+            CREATE TABLE `user_api_token_new` (
+                `user_id` INT(10) NOT NULL,
+                `token` CHAR(36) NOT NULL,
+                `device_name` VARCHAR(256) NOT NULL,
+                `user_agent_string` VARCHAR(256) NOT NULL,
+                `created_at` TEXT NOT NULL,
+                PRIMARY KEY (`token`),
+                UNIQUE (`user_id`),
+                FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE CASCADE
+            )
+            SQL,
+        );
+        $this->execute('INSERT INTO `user_api_token_new` (`user_id`, `token`, `created_at`) SELECT * FROM `user_api_token`');
+        $this->execute('DELETE `user_api_token`');
+        $this->execute('ALTER TABLE `user_api_token_new` RENAME TO `user_api_token`');
+    }
+}

--- a/db/migrations/sqlite/20240126110433_add_device_name_to_auth_token_table.php
+++ b/db/migrations/sqlite/20240126110433_add_device_name_to_auth_token_table.php
@@ -10,39 +10,41 @@ final class AddDeviceNameToAuthTokenTable extends AbstractMigration
     {
         $this->execute(
             <<<SQL
-            CREATE TABLE `user_api_token_old` (
-                `user_id` INT(10) NOT NULL,
-                `token` CHAR(36) NOT NULL,
+            CREATE TABLE `user_auth_token` (
+                `id` INTEGER NOT NULL,
+                `user_id` INTEGER NOT NULL,
+                `token` TEXT NOT NULL,
+                `expiration_date` TEXT NOT NULL,
                 `created_at` TEXT NOT NULL,
-                PRIMARY KEY (`token`),
-                UNIQUE (`user_id`),
-                FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE CASCADE
+                PRIMARY KEY (`id`),
+                FOREIGN KEY (`user_id`) REFERENCES user (`id`) ON DELETE CASCADE
             )
             SQL,
         );
-        $this->execute('INSERT INTO `user_api_token_old` (`user_id`, `token`, `created_at`) SELECT `user_id`, `token`, `created_at` FROM `user_api_token`');
-        $this->execute('DROP TABLE `user_api_token`');
-        $this->execute('ALTER TABLE `user_api_token_old` RENAME TO `user_api_token`');
+        $this->execute('INSERT INTO `user_auth_token_old` (`id`, `user_id`, `token`, `expiration_date`, `created_at`) SELECT `id`, `user_id`, `token`, `expiration_date`, `created_at` FROM `user_auth_token`');
+        $this->execute('DROP TABLE `user_auth_token`');
+        $this->execute('ALTER TABLE `user_auth_token_old` RENAME TO `user_auth_token`');
     }
 
     public function up() : void
     {
         $this->execute(
             <<<SQL
-            CREATE TABLE `user_api_token_new` (
+            CREATE TABLE `user_auth_token_new` (
+                `id` INTEGER NOT NULL,
                 `user_id` INT(10) NOT NULL,
                 `token` CHAR(36) NOT NULL,
                 `device_name` VARCHAR(256) NOT NULL,
                 `user_agent_string` VARCHAR(256) NOT NULL,
+                `expiration_date` TEXT NOT NULL,
                 `created_at` TEXT NOT NULL,
-                PRIMARY KEY (`token`),
-                UNIQUE (`user_id`),
-                FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE CASCADE
+                PRIMARY KEY (`id`),
+                FOREIGN KEY (`user_id`) REFERENCES user (`id`) ON DELETE CASCADE
             )
             SQL,
         );
-        $this->execute('INSERT INTO `user_api_token_new` (`user_id`, `token`, `created_at`) SELECT * FROM `user_api_token`');
-        $this->execute('DELETE `user_api_token`');
-        $this->execute('ALTER TABLE `user_api_token_new` RENAME TO `user_api_token`');
+        $this->execute('INSERT INTO `user_auth_token_new` (`id`, `user_id`, `token`, `expiration_date`, `created_at`) SELECT * FROM `user_auth_token`');
+        $this->execute('DROP TABLE `user_auth_token`');
+        $this->execute('ALTER TABLE `user_auth_token_new` RENAME TO `user_auth_token`');
     }
 }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1065,6 +1065,89 @@
           }
         }
       }
+    },
+    "/authentication/request-token": {
+      "post": {
+        "description": "Get an authentication token by submitting an email, password and optionally a time-based 6-digit code. This token can be stored and used for future requests to protected endpoints.",
+        "parameters": [{
+          "in": "header",
+          "name": "X-Movary-Client",
+          "schema": {
+            "type": "string"
+          },
+          "required": true,
+          "example": "Client Name"
+        }],
+        "requestBody": {
+          "description": "The credentials and optionally a two-factor Authentication code",
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "required": ["email", "password"],
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "example": "user@email.com",
+                    "description": "An email address"
+                  },
+                  "password": {
+                    "type": "string",
+                    "example": "mysecurepassword123",
+                    "description": "A password"
+                  },
+                  "totpCode": {
+                    "type": "integer",
+                    "pattern": "/^[0-9]{6}$/gm",
+                    "example": "123456",
+                    "description": "A 6-digit two-factor authentication code",
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string",
+                      "description": "The authentication token to be used in future requests."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "An authentication error. Either missing credentials or the credentials were invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "The name of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "The message of the error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1068,6 +1068,9 @@
     },
     "/authentication/request-token": {
       "post": {
+        "tags": [
+          "Authentication"
+        ],
         "description": "Get an authentication token by submitting an email, password and optionally a time-based 6-digit code. This token can be stored and used for future requests to protected endpoints.",
         "parameters": [{
           "in": "header",

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -1,0 +1,36 @@
+const MOVARY_CLIENT_IDENTIFIER = 'Movary Web';
+
+async function submitCredentials() {
+    const request = await fetch('/api/authentication/request-token', {
+        method: 'POST',
+        headers: {
+            'Content-type': 'application/json',
+            'X-Movary-Client': MOVARY_CLIENT_IDENTIFIER
+        },
+        body: JSON.stringify({
+            'email': document.getElementById('email').value,
+            'password': document.getElementById('password').value,
+            'rememberMe': document.getElementById('rememberMe').checked,
+            'totpCode': document.getElementById('totpCode').value
+        })
+    }).then((response) => {
+        return response;
+    });
+    
+    if(request.redirected === true) {
+        window.location.replace(request.url);
+    } else {
+        await request.json().then(error => {
+            if(error['error'] === 'NoVerificationCode') {
+               document.getElementById('LoginForm').classList.add('d-none');
+               document.getElementById('TotpForm').classList.remove('d-none');
+            } else if(error['error'] === 'InvalidTotpCode') {
+                addAlert('totpErrors', error['message'], 'danger', false);
+            } else {
+                addAlert('loginErrors', error['message'], 'danger', false);
+            }
+        }).catch(error => {
+            console.error(error);
+        });
+    }
+}

--- a/settings/routes.php
+++ b/settings/routes.php
@@ -20,7 +20,6 @@ function addWebRoutes(RouterService $routerService, FastRoute\RouteCollector $ro
     $routes->add('GET', '/', [Web\LandingPageController::class, 'render'], [Web\Middleware\UserIsUnauthenticated::class, Web\Middleware\ServerHasNoUsers::class]);
     $routes->add('GET', '/login', [Web\AuthenticationController::class, 'renderLoginPage'], [Web\Middleware\UserIsUnauthenticated::class]);
     $routes->add('POST', '/login', [Web\AuthenticationController::class, 'login']);
-    $routes->add('POST', '/verify-totp', [Web\TwoFactorAuthenticationController::class, 'verifyTotp'], [Web\Middleware\UserIsUnauthenticated::class]);
     $routes->add('GET', '/logout', [Web\AuthenticationController::class, 'logout']);
     $routes->add('POST', '/create-user', [Web\CreateUserController::class, 'createUser'], [
         Web\Middleware\UserIsUnauthenticated::class,

--- a/settings/routes.php
+++ b/settings/routes.php
@@ -203,6 +203,7 @@ function addApiRoutes(RouterService $routerService, FastRoute\RouteCollector $ro
     $routes = RouteList::create();
 
     $routes->add('GET', '/openapi', [Api\OpenApiController::class, 'getSchema']);
+    $routes->add('POST', '/authentication/request-token', [Api\AuthenticationController::class, 'requestToken']);
 
     $routeUserHistory = '/users/{username:[a-zA-Z0-9]+}/history/movies';
     $routes->add('GET', $routeUserHistory, [Api\HistoryController::class, 'getHistory'], [Api\Middleware\IsAuthorizedToReadUserData::class]);

--- a/src/Domain/User/Exception/InvalidTotpCode.php
+++ b/src/Domain/User/Exception/InvalidTotpCode.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Movary\Domain\User\Exception;
+
+class InvalidTotpCode extends InvalidCredentials
+{
+    public static function create() : self
+    {
+        return new self('Two-factor authentication code wrong.');
+    }
+}

--- a/src/Domain/User/Service/Authentication.php
+++ b/src/Domain/User/Service/Authentication.php
@@ -217,9 +217,9 @@ class Authentication
     }
 
 
-    private function verifyTotp($userId, $userTotpInput) : bool
+    private function verifyTotp(int $userId, int $userTotpInput) : bool
     {
-        if ($this->twoFactorAuthenticationApi->verifyTotpUri($userId, (int)$userTotpInput) === false) {
+        if ($this->twoFactorAuthenticationApi->verifyTotpUri($userId, $userTotpInput) === false) {
             return false;
         }
         return true;

--- a/src/Domain/User/Service/Authentication.php
+++ b/src/Domain/User/Service/Authentication.php
@@ -9,7 +9,6 @@ use Movary\Domain\User\Exception\NoVerificationCode;
 use Movary\Domain\User\UserApi;
 use Movary\Domain\User\UserEntity;
 use Movary\Domain\User\UserRepository;
-use Movary\Service\ServerSettings;
 use Movary\Util\SessionWrapper;
 use Movary\ValueObject\DateTime;
 use Movary\ValueObject\Http\Request;
@@ -24,7 +23,6 @@ class Authentication
         private readonly UserRepository $repository,
         private readonly UserApi $userApi,
         private readonly SessionWrapper $sessionWrapper,
-        private readonly ServerSettings $serverSettings,
         private readonly TwoFactorAuthenticationApi $twoFactorAuthenticationApi,
     ) {
     }
@@ -156,7 +154,6 @@ class Authentication
 
         session_regenerate_id();
         setcookie(self::AUTHENTICATION_COOKIE_NAME, $token, $cookieExpiration, '/');
-        // setcookie(self::AUTHENTICATION_COOKIE_NAME, $token, $cookieExpiration, '/', $this->serverSettings->getApplicationUrl(), true, true);
 
         $this->sessionWrapper->set('userId', $userId);
     }

--- a/src/Domain/User/UserRepository.php
+++ b/src/Domain/User/UserRepository.php
@@ -26,7 +26,7 @@ class UserRepository
         );
     }
 
-    public function createAuthToken(int $userId, string $token, DateTime $expirationDate) : void
+    public function createAuthToken(int $userId, string $token, string $deviceName, string $userAgent, DateTime $expirationDate) : void
     {
         $this->dbConnection->insert(
             'user_auth_token',
@@ -34,6 +34,8 @@ class UserRepository
                 'user_id' => $userId,
                 'token' => $token,
                 'expiration_date' => (string)$expirationDate,
+                'device_name' => $deviceName,
+                'user_agent_string' => $userAgent,
                 'created_at' => (string)DateTime::create(),
             ],
         );

--- a/src/HttpController/Api/AuthenticationController.php
+++ b/src/HttpController/Api/AuthenticationController.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace Movary\HttpController\Api;
+
+use Movary\Domain\User\Exception\InvalidCredentials;
+use Movary\Domain\User\Exception\InvalidTotpCode;
+use Movary\Domain\User\Exception\NoVerificationCode;
+use Movary\Domain\User\Service\Authentication;
+use Movary\Domain\User\Service\TwoFactorAuthenticationApi;
+use Movary\Util\Json;
+use Movary\Util\SessionWrapper;
+use Movary\ValueObject\Http\Request;
+use Movary\ValueObject\Http\Response;
+
+class AuthenticationController
+{
+    public function __construct(
+        private readonly Authentication $authenticationService,
+        private readonly TwoFactorAuthenticationApi $twoFactorAuthenticationApi,
+        private readonly SessionWrapper $sessionWrapper,
+    ) {
+    }
+
+    public function requestToken(Request $request) : Response
+    {
+        $postParameters = Json::decode($request->getBody());
+        $headers = $request->getHeaders();
+        if($postParameters['email'] === null || $postParameters['password'] === null) {
+            return Response::createBadRequest('Username or password has not been provided');
+        }
+        $totpCode = $postParameters['totpCode'] ?? 0;
+        
+        if(isset($headers['X-Movary-Client']) === false) {
+            return Response::createBadRequest();
+        }
+        
+        $client = $headers['X-Movary-Client'];
+
+        try {
+            $this->authenticationService->login($postParameters['email'], $postParameters['password'], false, (int)$totpCode);
+
+            if($client === 'Movary Web') {
+                $redirect = $postParameters['redirect'] ?? null;
+                $target = $redirect ?? $_SERVER['HTTP_REFERER'];
+        
+                $urlParts = parse_url($target);
+                if (is_array($urlParts) === false) {
+                    $urlParts = ['path' => '/'];
+                }
+                $query = $urlParts['query'] ?? '';
+
+                /* @phpstan-ignore-next-line */
+                $targetRelativeUrl = $urlParts['path'] . $query;
+        
+                return Response::createSeeOther($targetRelativeUrl);
+            }
+            
+            return Response::createJson(Json::encode(['token' => $this->authenticationService->getToken()]));
+        } catch (InvalidCredentials $e) {
+            return Response::createBadRequest(Json::encode([
+                'error' => basename(str_replace('\\', '/', get_class($e))),
+                'message' => $e->getMessage()
+            ]));
+        }
+    }
+}

--- a/src/HttpController/Api/AuthenticationController.php
+++ b/src/HttpController/Api/AuthenticationController.php
@@ -29,6 +29,8 @@ class AuthenticationController
             return Response::createBadRequest('Username or password has not been provided');
         }
         $totpCode = $postParameters['totpCode'] ?? 0;
+        $rememberMe = (bool)$postParameters['rememberMe'] ?? false;
+        $userAgent = $request->getUserAgent();
         
         if(isset($headers['X-Movary-Client']) === false) {
             return Response::createBadRequest();
@@ -37,7 +39,7 @@ class AuthenticationController
         $client = $headers['X-Movary-Client'];
 
         try {
-            $this->authenticationService->login($postParameters['email'], $postParameters['password'], false, (int)$totpCode);
+            $this->authenticationService->login($postParameters['email'], $postParameters['password'], $rememberMe, $client, $userAgent, (int)$totpCode);
 
             if($client === 'Movary Web') {
                 $redirect = $postParameters['redirect'] ?? null;

--- a/src/HttpController/Api/AuthenticationController.php
+++ b/src/HttpController/Api/AuthenticationController.php
@@ -3,12 +3,8 @@
 namespace Movary\HttpController\Api;
 
 use Movary\Domain\User\Exception\InvalidCredentials;
-use Movary\Domain\User\Exception\InvalidTotpCode;
-use Movary\Domain\User\Exception\NoVerificationCode;
 use Movary\Domain\User\Service\Authentication;
-use Movary\Domain\User\Service\TwoFactorAuthenticationApi;
 use Movary\Util\Json;
-use Movary\Util\SessionWrapper;
 use Movary\ValueObject\Http\Request;
 use Movary\ValueObject\Http\Response;
 
@@ -16,8 +12,6 @@ class AuthenticationController
 {
     public function __construct(
         private readonly Authentication $authenticationService,
-        private readonly TwoFactorAuthenticationApi $twoFactorAuthenticationApi,
-        private readonly SessionWrapper $sessionWrapper,
     ) {
     }
 
@@ -29,7 +23,7 @@ class AuthenticationController
             return Response::createBadRequest('Username or password has not been provided');
         }
         $totpCode = $postParameters['totpCode'] ?? 0;
-        $rememberMe = (bool)$postParameters['rememberMe'] ?? false;
+        $rememberMe = (bool)$postParameters['rememberMe'];
         $userAgent = $request->getUserAgent();
         
         if(isset($headers['X-Movary-Client']) === false) {

--- a/src/HttpController/Web/AuthenticationController.php
+++ b/src/HttpController/Web/AuthenticationController.php
@@ -4,6 +4,7 @@ namespace Movary\HttpController\Web;
 
 use Movary\Domain\SessionService;
 use Movary\Domain\User\Exception\InvalidCredentials;
+use Movary\Domain\User\Exception\InvalidTotpCode;
 use Movary\Domain\User\Exception\NoVerificationCode;
 use Movary\Domain\User\Service;
 use Movary\Util\SessionWrapper;

--- a/src/HttpController/Web/AuthenticationController.php
+++ b/src/HttpController/Web/AuthenticationController.php
@@ -23,39 +23,6 @@ class AuthenticationController
     ) {
     }
 
-    public function login(Request $request) : Response
-    {
-        $postParameters = $request->getPostParameters();
-
-        try {
-            $this->authenticationService->login(
-                $postParameters['email'],
-                $postParameters['password'],
-                isset($postParameters['rememberMe']) === true,
-            );
-        } catch (NoVerificationCode) {
-            $this->sessionWrapper->set('useTwoFactorAuthentication', true);
-        } catch (InvalidCredentials) {
-            $this->sessionWrapper->set('failedLogin', true);
-        }
-        $redirect = $postParameters['redirect'];
-        $target = $redirect ?? $_SERVER['HTTP_REFERER'];
-
-        $urlParts = parse_url($target);
-        if (is_array($urlParts) === false) {
-            $urlParts = ['path' => '/'];
-        }
-
-        /* @phpstan-ignore-next-line */
-        $targetRelativeUrl = $urlParts['path'] . $urlParts['query'] ?? '';
-
-        return Response::create(
-            StatusCode::createSeeOther(),
-            null,
-            [Header::createLocation($targetRelativeUrl)],
-        );
-    }
-
     public function logout() : Response
     {
         $this->authenticationService->logout();

--- a/src/HttpController/Web/CreateUserController.php
+++ b/src/HttpController/Web/CreateUserController.php
@@ -18,6 +18,8 @@ use Twig\Environment;
 
 class CreateUserController
 {
+    private const MOVARY_WEB_CLIENT = 'Movary Web';
+    
     public function __construct(
         private readonly Environment $twig,
         private readonly Authentication $authenticationService,
@@ -32,6 +34,7 @@ class CreateUserController
         $hasUsers = $this->userApi->hasUsers();
         $postParameters = $request->getPostParameters();
 
+        $userAgent = $request->getUserAgent();
         $email = empty($postParameters['email']) === true ? null : (string)$postParameters['email'];
         $name = empty($postParameters['name']) === true ? null : (string)$postParameters['name'];
         $password = empty($postParameters['password']) === true ? null : (string)$postParameters['password'];
@@ -60,7 +63,7 @@ class CreateUserController
         try {
             $this->userApi->createUser($email, $password, $name, $hasUsers === false);
 
-            $this->authenticationService->login($email, $password, false);
+            $this->authenticationService->login($email, $password, false, self::MOVARY_WEB_CLIENT, $userAgent);
         } catch (PasswordTooShort) {
             $this->sessionWrapper->set('errorPasswordTooShort', true);
         } catch (UsernameInvalidFormat) {

--- a/src/HttpController/Web/LandingPageController.php
+++ b/src/HttpController/Web/LandingPageController.php
@@ -22,30 +22,13 @@ class LandingPageController
 
     public function render() : Response
     {
-        $failedLogin = $this->sessionWrapper->has('failedLogin');
         $deletedAccount = $this->sessionWrapper->has('deletedAccount');
-        $invalidTotpCode = $this->sessionWrapper->has('invalidTotpCode');
-        $useTwoFactorAuthentication = $this->sessionWrapper->has('useTwoFactorAuthentication');
-
-        $this->sessionWrapper->unset('failedLogin', 'deletedAccount', 'invalidTotpCode', 'useTwoFactorAuthentication');
-        if ($invalidTotpCode === true) {
-            $useTwoFactorAuthentication = true;
-        }
-
-        if ($useTwoFactorAuthentication === false) {
-            $this->sessionWrapper->unset('rememberMe');
-        }
 
         return Response::create(
             StatusCode::createOk(),
             $this->twig->render('page/login.html.twig', [
-                'failedLogin' => $failedLogin,
                 'deletedAccount' => $deletedAccount,
                 'registrationEnabled' => $this->registrationEnabled,
-                'defaultEmail' => $this->defaultEmail,
-                'defaultPassword' => $this->defaultPassword,
-                'useTwoFactorAuthentication' => $useTwoFactorAuthentication,
-                'invalidTotpCode' => $invalidTotpCode,
             ]),
         );
     }

--- a/src/HttpController/Web/LandingPageController.php
+++ b/src/HttpController/Web/LandingPageController.php
@@ -29,6 +29,8 @@ class LandingPageController
             $this->twig->render('page/login.html.twig', [
                 'deletedAccount' => $deletedAccount,
                 'registrationEnabled' => $this->registrationEnabled,
+                'defaultEmail' => $this->defaultEmail,
+                'defaultPassword' => $this->defaultPassword
             ]),
         );
     }

--- a/src/HttpController/Web/OpenApiController.php
+++ b/src/HttpController/Web/OpenApiController.php
@@ -17,17 +17,17 @@ class OpenApiController
 
     public function renderPage() : Response
     {
-        $openAiJsonUrl = '/api/openapi';
+        $openApiJsonUrl = '/api/openapi';
 
         $applicationUrl = $this->serverSettings->getApplicationUrl();
         if ($applicationUrl !== null) {
-            $openAiJsonUrl = trim($applicationUrl, '/') . $openAiJsonUrl;
+            $openApiJsonUrl = trim($applicationUrl, '/') . $openApiJsonUrl;
         }
 
         return Response::create(
             StatusCode::createOk(),
             $this->twig->render('page/api.html.twig', [
-                'openAiJsonUrl' => $openAiJsonUrl
+                'openApiJsonUrl' => $openApiJsonUrl
             ]),
         );
     }

--- a/src/HttpController/Web/TwoFactorAuthenticationController.php
+++ b/src/HttpController/Web/TwoFactorAuthenticationController.php
@@ -61,29 +61,4 @@ class TwoFactorAuthenticationController
 
         return Response::createOk();
     }
-
-    public function verifyTotp(Request $request) : Response
-    {
-        $userTotpInput = $request->getPostParameters()['totpCode'];
-        $rememberMe = $this->sessionWrapper->find('rememberMe') ?? false;
-        $userId = (int)$this->sessionWrapper->find('totpUserId');
-
-        if ($this->twoFactorAuthenticationApi->verifyTotpUri($userId, (int)$userTotpInput) === false) {
-            $this->sessionWrapper->set('invalidTotpCode', true);
-
-            return Response::create(
-                StatusCode::createSeeOther(),
-                null,
-                [Header::createLocation($_SERVER['HTTP_REFERER'])],
-            );
-        }
-
-        $this->authenticationService->createAuthenticationCookie($userId, $rememberMe);
-
-        return Response::create(
-            StatusCode::createSeeOther(),
-            null,
-            [Header::createLocation($_SERVER['HTTP_REFERER'])],
-        );
-    }
 }

--- a/src/ValueObject/Http/Request.php
+++ b/src/ValueObject/Http/Request.php
@@ -15,6 +15,7 @@ class Request
         private readonly string $body,
         private readonly array $filesParameters,
         private readonly array $headers,
+        private readonly string $userAgent
     ) {
     }
 
@@ -27,10 +28,11 @@ class Request
         $postParameters = self::extractPostParameter();
         $filesParameters = self::extractFilesParameter();
         $headers = self::extractHeaders();
+        $userAgent = self::extractUserAgent();
 
         $body = (string)file_get_contents('php://input');
 
-        return new self($path, $getParameters, $postParameters, $body, $filesParameters, $headers);
+        return new self($path, $getParameters, $postParameters, $body, $filesParameters, $headers, $userAgent);
     }
 
     private static function extractFilesParameter() : array
@@ -87,6 +89,11 @@ class Request
         return self::getServerSetting('REQUEST_URI') ?? '';
     }
 
+    private static function extractUserAgent() : string
+    {
+        return self::getServerSetting('HTTP_USER_AGENT') ?? '';
+    }
+
     private static function getServerSetting(string $key) : ?string
     {
         return empty($_SERVER[$key]) === false ? (string)$_SERVER[$key] : null;
@@ -130,5 +137,10 @@ class Request
     public function getRouteParameters() : array
     {
         return $this->routeParameters;
+    }
+
+    public function getUserAgent() : string
+    {
+        return $this->userAgent;
     }
 }

--- a/templates/page/api.html.twig
+++ b/templates/page/api.html.twig
@@ -12,7 +12,7 @@
 <script>
     window.onload = () => {
         window.ui = SwaggerUIBundle({
-            url: "{{ openAiJsonUrl }}",
+            url: "{{ openApiJsonUrl }}",
             dom_id: '#swagger-ui',
         });
     };

--- a/templates/page/login.html.twig
+++ b/templates/page/login.html.twig
@@ -20,19 +20,19 @@
             <form id="LoginForm">
                 <h1 id="header" class="text-{{ theme == 'dark' ? 'light' : 'dark' }}" style="margin-bottom: 1rem">{{ applicationName ?? 'Movary' }}</h1>
                 <div class="form-floating">
-                    <input type="email" name="email" value="{{ defaultEmail }}" class="form-control text-{{ theme == 'dark' ? 'light' : 'dark' }}" id="email"
+                    <input type="email" value="{{ defaultEmail }}" class="form-control text-{{ theme == 'dark' ? 'light' : 'dark' }}" id="email"
                         placeholder="name@example.com" required>
                     <label for="email">Email address</label>
                 </div>
                 <div class="form-floating">
-                    <input type="password" name="password" value="{{ defaultPassword }}" class="form-control text-{{ theme == 'dark' ? 'light' : 'dark' }}" id="password"
+                    <input type="password" value="{{ defaultPassword }}" class="form-control text-{{ theme == 'dark' ? 'light' : 'dark' }}" id="password"
                         placeholder="Password" required>
                     <label for="password">Password</label>
                 </div>
 
                 <div class="checkbox mb-3" style="margin-bottom: 0.7rem!important;">
                     <label class="text-{{ theme == 'dark' ? 'light' : 'dark' }}">
-                        <input type="checkbox" name="rememberMe" id="rememberMe" value="true" {{ defaultRememberMe == 'true' ? 'checked' : '' }}> Remember me
+                        <input type="checkbox" id="rememberMe" value="true" {{ defaultRememberMe == 'true' ? 'checked' : '' }}> Remember me
                     </label>
                 </div>
 
@@ -57,7 +57,6 @@
             <form id="TotpForm" class="d-none">
                 <p style="margin-bottom: 0">Enter the 6 digit verification code from your authenticator app.</p>
                 <input type="text"
-                    name="totpCode"
                     class="form-control form-control-lg text-{{ theme == 'dark' ? 'light' : 'dark' }}"
                     placeholder="Verification code"
                     maxlength="6"

--- a/templates/page/login.html.twig
+++ b/templates/page/login.html.twig
@@ -8,74 +8,66 @@
     <link rel="stylesheet" href="/css/login.css">
 {% endblock %}
 
+{% block scripts %}
+    <script src="/js/login.js"></script>
+{% endblock %}
+
 {% block body %}
     <script>
         if ("{{ theme }}" === 'dark') document.getElementsByTagName('body')[0].classList.add('bg-dark')
     </script>
-    <main role="main" class="form-signin w-100 m-auto text-center">
-        {% if useTwoFactorAuthentication == false %}
-            <form action="/login" method="post" enctype="multipart/form-data">
+        <main role="main" class="form-signin w-100 m-auto text-center">
+            <form id="LoginForm">
                 <h1 id="header" class="text-{{ theme == 'dark' ? 'light' : 'dark' }}" style="margin-bottom: 1rem">{{ applicationName ?? 'Movary' }}</h1>
                 <div class="form-floating">
-                    <input type="email" name="email" value="{{ defaultEmail }}" class="form-control text-{{ theme == 'dark' ? 'light' : 'dark' }}" id="floatingInput"
-                           placeholder="name@example.com" required>
-                    <label for="floatingInput">Email address</label>
+                    <input type="email" name="email" value="{{ defaultEmail }}" class="form-control text-{{ theme == 'dark' ? 'light' : 'dark' }}" id="email"
+                        placeholder="name@example.com" required>
+                    <label for="email">Email address</label>
                 </div>
                 <div class="form-floating">
-                    <input type="password" name="password" value="{{ defaultPassword }}" class="form-control text-{{ theme == 'dark' ? 'light' : 'dark' }}" id="floatingPassword"
-                           placeholder="Password" required>
-                    <label for="floatingPassword">Password</label>
+                    <input type="password" name="password" value="{{ defaultPassword }}" class="form-control text-{{ theme == 'dark' ? 'light' : 'dark' }}" id="password"
+                        placeholder="Password" required>
+                    <label for="password">Password</label>
                 </div>
 
                 <div class="checkbox mb-3" style="margin-bottom: 0.7rem!important;">
                     <label class="text-{{ theme == 'dark' ? 'light' : 'dark' }}">
-                        <input type="checkbox" name="rememberMe" value="true"> Remember me
+                        <input type="checkbox" name="rememberMe" id="rememberMe" value="true" {{ defaultRememberMe == 'true' ? 'checked' : '' }}> Remember me
                     </label>
                 </div>
+
+                <div id="loginErrors"></div>
 
                 {% if deletedAccount == true %}
                     <div class="alert alert-success" role="alert" style="margin-bottom: 0.7rem!important;">
                         Account deleted successfully.
                     </div>
                 {% endif %}
-                {% if failedLogin == true %}
-                    <div class="alert alert-danger" role="alert" style="margin-bottom: 0.7rem!important;">
-                        Invalid credentials
-                    </div>
-                {% else %}
                 {% if redirect != false %}
                     <div class="alert alert-danger" role="alert" style="margin-bottom: 0.7rem!important;">
                         Sign in to access page
                     </div>
                     <input type="hidden" value="{{ redirect }}" name="redirect" />
                 {% endif %}
-                {% endif %}
-                <button class="w-100 btn btn-lg btn-primary mb-3" type="submit">Sign in</button>
+                <button class="w-100 btn btn-lg btn-primary mb-3" type="button" onclick="submitCredentials()">Sign in</button>
                 {% if registrationEnabled == true %}
                     <a href="/create-user">Create new user</a>
                 {% endif %}
             </form>
-        {% elseif useTwoFactorAuthentication == true %}
-            <form action="/verify-totp" method="post">
+            <form id="TotpForm" class="d-none">
                 <p style="margin-bottom: 0">Enter the 6 digit verification code from your authenticator app.</p>
                 <input type="text"
-                       name="totpCode"
-                       class="form-control form-control-lg text-{{ theme == 'dark' ? 'light' : 'dark' }}" id="floatingVerificationCode"
-                       placeholder="Verification code"
-                       maxlength="6"
-                       autocomplete="off"
-                       style="margin-bottom: .7rem;margin-top: .7rem"
-                       required>
-                {% if invalidTotpCode == true %}
-                    <div class="alert alert-danger alert-dismissible" role="alert" style="margin-bottom: 0.7rem!important;margin-top: .7rem">
-                        Invalid verification code
-                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                    </div>
-                {% endif %}
-                <button class="w-100 btn btn-lg btn-primary mb-3" type="submit" style="margin-bottom: .7rem!important;">Continue</button>
+                    name="totpCode"
+                    class="form-control form-control-lg text-{{ theme == 'dark' ? 'light' : 'dark' }}"
+                    placeholder="Verification code"
+                    maxlength="6"
+                    autocomplete="off"
+                    style="margin-bottom: .7rem;margin-top: .7rem"
+                    id="totpCode"
+                    required>
+                <div id="totpErrors"></div>
+                <button class="w-100 btn btn-lg btn-primary mb-3" type="button" style="margin-bottom: .7rem!important;" onclick="submitCredentials()">Continue</button>
+                <a href="/">Back</a>
             </form>
-            <a href="/">Back</a>
-        {% endif %}
-
-    </main>
+        </main>
 {% endblock %}


### PR DESCRIPTION
This PR adds ``/authentication/request-token` where an HTTP POST request should be sent.

It also adds a new header, `X-Movary-Client`, which allows the backend to distinguish the default Movary frontend from any 3rd-party apps that may want to use Movary's authentication.

This is important, because if it's just a 3rd-party, Movary will only return the token in JSON format while if it's the Movary frontend, the backend will return a HTTP 303 response. I stole this idea from the Plex API, which does the same, only with `X-Plex-Product` instead. 

Additionally, I have added two columns to the `user_auth_tokens` table containing the Device Name (aka the value from `X-Movary-Client`) and the user agent string from the HTTP request. This allows us to add a new feature in the future, where the users can see all the tokens /  devices and invalidate any token / authorized sessions. The user can see which token belongs to which app and which user agent was used to request the token. Maybe we should store the IP as well? And maybe another column containing the date that the token was last used.

Anyway, the default client name for the Movary frontend is 'Movary Web'.

The login process for the current Twig frontend has already been migrated from the old web endpoint to the API. It no longer works with the POST form, but instead JS is used to send the POST request; this is to allow a smooth transition to a TOTP form if it's necessary.

Also, the verification of the TOTP code has been moved from the `TwoFactorAuthenticationController` to the new API `AuthenticationController`. I did this because now the user can log in with the TOTP code with one HTTP request, instead of two different requests. The 2FA controller is still used for enabling / disabling the 2FA though.