### PR TITLE
Add support for preflight requests with CORS

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -5,6 +5,7 @@ session_start();
 /** @var DI\Container $container */
 
 use Movary\HttpController\Web\ErrorController;
+use Movary\HttpController\Api\PreflightRequestController;
 use Movary\ValueObject\Http\Request;
 use Movary\ValueObject\Http\Response;
 use Psr\Log\LoggerInterface;
@@ -55,6 +56,10 @@ try {
 
     if ($response->getStatusCode()->getCode() === 404 && str_starts_with($uri, '/api') === false) {
         $response = $container->get(ErrorController::class)->renderNotFound($httpRequest);
+    }
+
+    if($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+        $response = $container->get(PreflightRequestController::class)->handleRequest($httpRequest, $dispatcher);
     }
 } catch (Throwable $t) {
     $container->get(LoggerInterface::class)->emergency($t->getMessage(), ['exception' => $t]);

--- a/src/HttpController/Api/PreflightRequestController.php
+++ b/src/HttpController/Api/PreflightRequestController.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+namespace Movary\HttpController\Api;
+
+use Movary\ValueObject\Http\Request;
+use FastRoute;
+use Movary\ValueObject\Config;
+use Movary\ValueObject\Http\Response;
+
+class PreflightRequestController
+{
+    public function __construct(
+        private readonly Config $config
+    ) { }
+
+    public function handleRequest(Request $request, FastRoute\Dispatcher $dispatcher) : Response
+    {
+        $requestedRoute = $request->getPath();
+        $dispatch = $dispatcher->dispatch('OPTIONS', $requestedRoute);
+        if($dispatch[0] === FastRoute\Dispatcher::NOT_FOUND) {
+            return Response::createNotFound();
+        }
+        $methods = $dispatch[1] ?? [];
+        array_push($methods, 'OPTIONS');
+        $origin = $this->config->getAsString('FRONTEND_URL', $this->config->getAsString('APPLICATION_URL', '*'));
+        return Response::createCors($methods, $origin);
+    }
+}

--- a/src/ValueObject/Http/Header.php
+++ b/src/ValueObject/Http/Header.php
@@ -25,6 +25,17 @@ class Header
         return new self('Location', $value);
     }
 
+    public static function createCorsHeaders(array $methods, string $origin = '*') : array
+    {
+        return [
+            new self('Access-Control-Allow-Origin', $origin),
+            new self('Access-Control-Allow-Credentials', 'true'),
+            new self('Access-Control-Max-Age', '60'),
+            new self('Access-Control-Allow-Headers', 'X-Movary-Client, Content-Type, Content-Type-Body, accept'),
+            new self('Access-Control-Allow-Methods', implode(', ', $methods))
+        ];
+    }
+
     public function __toString() : string
     {
         return $this->name . ': ' . $this->value;

--- a/src/ValueObject/Http/Response.php
+++ b/src/ValueObject/Http/Response.php
@@ -24,6 +24,11 @@ class Response
         return new self(StatusCode::createBadRequest(), $body);
     }
 
+    public static function createCors(array $methods, string $origin) : self
+    {
+        return new self(StatusCode::createOk(), null, Header::createCorsHeaders($methods, $origin));
+    }
+
     public static function createCsv(string $body) : self
     {
         return new self(StatusCode::createOk(), $body, [Header::createContentTypeCsv()]);


### PR DESCRIPTION
While working on the new frontend, I encountered a new problem.

The Movary backend runs on a different address than the frontend. The frontend sends HTTP requests to a different address and due this, we need a proper Cross-Origin-Resource-Sharing (CORS) policy. More info [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS).

To 'discover' the CORS policy, the browser sends a [preflight](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS) request. This request is basically asking what methods are allowed for the API endpoint and this PR adds a proper response to the request.

