### PR TITLE
Add authentication check endpoint

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1066,13 +1066,13 @@
         }
       }
     },
-    "/authentication/authenticated": {
+    "/authentication/token": {
       "get": {
         "tags": [
           "Authentication"
         ],
-        "summary": "Checks the authentication status of the user.",
-        "description": "Checks if the user is authenticated based on cookie.. The response is a JSON object with the authentication status and an optional username + userId of the authenticated user",
+        "summary": "Retrieves the authhentication data",
+        "description": "Gets the user ID, the username and whether the user is admin or not, based on a token in either a header or a cookie.",
         "responses": {
           "200": {
             "description": "OK",
@@ -1081,35 +1081,49 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "authenticated": {
-                      "type": "boolean",
-                      "description": "True if authenticated, false if unauthenticated."
-                    },
-                    "username": {
-                      "type": "string",
-                      "description": "The username of the authenticated user. It's empty if the user is unauthenticated."
-                    },
-                    "userId": {
-                      "type": "integer",
-                      "description": "The ID of the authenticated user. It's empty if the user is unauthenticated."
-                    },
-                    "isAdmin": {
-                      "type": "boolean",
-                      "description": "True if the user is an admin, False if the user isn't."
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "The username of the user"
+                        },
+                        "userId": {
+                          "type": "integer",
+                          "description": "The ID of the authenticated user"
+                        },
+                        "isAdmin": {
+                          "type": "boolean",
+                          "description": "True if the user is an admin, False if the user isn't."
+                        }
+                      }
                     }
                   }
                 }
               }
             }
+          },
+          "400": {
+            "description": "Authentication token is missing in both the header and the cookie"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
           }
-        }
-      }
-    },
-    "/authentication/token": {
+        },
+        "security": [
+          {
+            "token": []
+          },
+          {
+            "cookie": []
+          }
+        ]
+      },
       "post": {
         "tags": [
           "Authentication"
         ],
+        "summary": "Create an authentication token",
         "description": "Create an authentication token via email, password and optionally TOTP code. Add the token as X-Auth-Token header to further requests. Token lifetime 1d default, 30d with rememberMe.",
         "parameters": [
           {
@@ -1170,13 +1184,26 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "userId": {
-                      "type": "integer",
-                      "description": "The id of the authenticated user."
-                    },
-                    "token": {
+                    "authToken": {
                       "type": "string",
                       "description": "The authentication token to be used in future requests."
+                    },
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "The username of the user"
+                        },
+                        "userId": {
+                          "type": "integer",
+                          "description": "The ID of the authenticated user"
+                        },
+                        "isAdmin": {
+                          "type": "boolean",
+                          "description": "True if the user is an admin, False if the user isn't."
+                        }
+                      }
                     }
                   }
                 }
@@ -1195,6 +1222,7 @@
         "tags": [
           "Authentication"
         ],
+        "summary": "Delete authentication token",
         "description": "Delete the authentication token provided in the X-Auth-Token header value.",
         "parameters": [
           {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1066,6 +1066,45 @@
         }
       }
     },
+    "/authentication/authenticated": {
+      "get": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "Checks the authentication status of the user.",
+        "description": "Checks if the user is authenticated based on cookie.. The response is a JSON object with the authentication status and an optional username + userId of the authenticated user",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "authenticated": {
+                      "type": "boolean",
+                      "description": "True if authenticated, false if unauthenticated."
+                    },
+                    "username": {
+                      "type": "string",
+                      "description": "The username of the authenticated user. It's empty if the user is unauthenticated."
+                    },
+                    "userId": {
+                      "type": "integer",
+                      "description": "The ID of the authenticated user. It's empty if the user is unauthenticated."
+                    },
+                    "isAdmin": {
+                      "type": "boolean",
+                      "description": "True if the user is an admin, False if the user isn't."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/authentication/token": {
       "post": {
         "tags": [

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1072,7 +1072,7 @@
           "Authentication"
         ],
         "summary": "Retrieves the authhentication data",
-        "description": "Gets the user ID, the username and whether the user is admin or not, based on a token in either a header or a cookie.",
+        "description": "Gets the user ID, the username and whether the user is admin or not, based on a token in the header.",
         "responses": {
           "200": {
             "description": "OK",
@@ -1104,7 +1104,7 @@
             }
           },
           "400": {
-            "description": "Authentication token is missing in both the header and the cookie"
+            "description": "Authentication token is missing in the header."
           },
           "401": {
             "$ref": "#/components/responses/401"
@@ -1113,9 +1113,6 @@
         "security": [
           {
             "token": []
-          },
-          {
-            "cookie": []
           }
         ]
       },
@@ -1466,11 +1463,6 @@
         "type": "apiKey",
         "name": "X-Auth-Token",
         "in": "header"
-      },
-      "cookie": {
-        "type": "apiKey",
-        "name": "id",
-        "in": "cookie"
       }
     }
   }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1071,8 +1071,18 @@
         "tags": [
           "Authentication"
         ],
-        "summary": "Retrieves the authhentication data",
-        "description": "Gets the user ID, the username and whether the user is admin or not, based on a token in the header.",
+        "summary": "Get authentication data",
+        "description": "Get information about the authenticated user.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Auth-Token",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1086,15 +1096,15 @@
                       "properties": {
                         "name": {
                           "type": "string",
-                          "description": "The username of the user"
+                          "description": "The name of the user"
                         },
                         "userId": {
                           "type": "integer",
-                          "description": "The ID of the authenticated user"
+                          "description": "The id of the user"
                         },
                         "isAdmin": {
                           "type": "boolean",
-                          "description": "True if the user is an admin, False if the user isn't."
+                          "description": "True if user is an admin, false if not."
                         }
                       }
                     }
@@ -1104,7 +1114,7 @@
             }
           },
           "400": {
-            "description": "Authentication token is missing in the header."
+            "$ref": "#/components/responses/400"
           },
           "401": {
             "$ref": "#/components/responses/401"
@@ -1120,7 +1130,7 @@
         "tags": [
           "Authentication"
         ],
-        "summary": "Create an authentication token",
+        "summary": "Create authentication token",
         "description": "Create an authentication token via email, password and optionally TOTP code. Add the token as X-Auth-Token header to further requests. Token lifetime 1d default, 30d with rememberMe.",
         "parameters": [
           {

--- a/settings/phpcs.xml
+++ b/settings/phpcs.xml
@@ -18,7 +18,11 @@
     <rule ref="Generic.Commenting.Fixme"/>
     <rule ref="Generic.ControlStructures.InlineControlStructure"/>
     <rule ref="Generic.Files.ByteOrderMark"/>
-    <rule ref="Generic.Files.LineEndings"/>
+    <rule ref="Generic.Files.LineEndings">
+        <rule ref="Generic.Files.LineEndings">
+            <exclude name="Generic.Files.LineEndings.InvalidEOLChar"/>
+        </rule>
+    </rule>
     <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
     <rule ref="Generic.Formatting.NoSpaceAfterCast"/>
     <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>

--- a/settings/routes.php
+++ b/settings/routes.php
@@ -203,6 +203,7 @@ function addApiRoutes(RouterService $routerService, FastRoute\RouteCollector $ro
 
     $routes->add('GET', '/openapi', [Api\OpenApiController::class, 'getSchema']);
     $routes->add('POST', '/authentication/token', [Api\AuthenticationController::class, 'createToken']);
+    $routes->add('GET', '/authentication/authenticated', [Api\AuthenticationController::class, 'isAuthenticated']);
 
     $routeUserHistory = '/users/{username:[a-zA-Z0-9]+}/history/movies';
     $routes->add('GET', $routeUserHistory, [Api\HistoryController::class, 'getHistory'], [Api\Middleware\IsAuthorizedToReadUserData::class]);

--- a/settings/routes.php
+++ b/settings/routes.php
@@ -202,7 +202,7 @@ function addApiRoutes(RouterService $routerService, FastRoute\RouteCollector $ro
     $routes->add('GET', '/openapi', [Api\OpenApiController::class, 'getSchema']);
     $routes->add('POST', '/authentication/token', [Api\AuthenticationController::class, 'createToken']);
     $routes->add('DELETE', '/authentication/token', [Api\AuthenticationController::class, 'destroyToken']);
-    $routes->add('GET', '/authentication/authenticated', [Api\AuthenticationController::class, 'isAuthenticated']);
+    $routes->add('GET', '/authentication/token', [Api\AuthenticationController::class, 'getTokenData']);
 
     $routeUserHistory = '/users/{username:[a-zA-Z0-9]+}/history/movies';
     $routes->add('GET', $routeUserHistory, [Api\HistoryController::class, 'getHistory'], [Api\Middleware\IsAuthorizedToReadUserData::class]);

--- a/src/Domain/User/Service/Authentication.php
+++ b/src/Domain/User/Service/Authentication.php
@@ -122,7 +122,7 @@ class Authentication
     {
         $token = filter_input(INPUT_COOKIE, self::AUTHENTICATION_COOKIE_NAME);
 
-        if (empty($token) === false && $this->isValidToken((string)$token) === true) {
+        if (empty($token) === false && $this->isValidAuthToken((string)$token) === true) {
             return true;
         }
 
@@ -164,7 +164,7 @@ class Authentication
         return $this->isUserAuthenticatedWithCookie() === true && $this->getCurrentUserId() === $userId;
     }
 
-    public function isValidToken(string $token) : bool
+    public function isValidAuthToken(string $token) : bool
     {
         $tokenExpirationDate = $this->repository->findAuthTokenExpirationDate($token);
 

--- a/src/Domain/User/Service/Authentication.php
+++ b/src/Domain/User/Service/Authentication.php
@@ -98,14 +98,19 @@ class Authentication
         return $userId;
     }
 
-    public function getToken() : ?string
+    public function getToken(Request $request) : ?string
     {
-        return $_COOKIE[self::AUTHENTICATION_COOKIE_NAME];
+        $tokenInCookie = filter_input(INPUT_COOKIE, self::AUTHENTICATION_COOKIE_NAME);
+        if ($tokenInCookie !== false && $tokenInCookie !== null) {
+            return $tokenInCookie;
+        }
+
+        return $request->getHeaders()['X-Auth-Token'] ?? null;
     }
 
     public function getUserIdByApiToken(Request $request) : ?int
     {
-        $apiToken = $request->getHeaders()['X-Auth-Token'] ?? filter_input(INPUT_COOKIE, self::AUTHENTICATION_COOKIE_NAME) ?? null;
+        $apiToken = $this->getToken($request);
         if ($apiToken === null) {
             return null;
         }

--- a/src/HttpController/Api/AuthenticationController.php
+++ b/src/HttpController/Api/AuthenticationController.php
@@ -89,7 +89,7 @@ class AuthenticationController
                 'authToken' => $userAndAuthToken['token'],
                 'user' => [
                     'id' => $userAndAuthToken['user']->getId(),
-                    'username' => $userAndAuthToken['user']->getName(),
+                    'name' => $userAndAuthToken['user']->getName(),
                     'isAdmin' => $userAndAuthToken['user']->isAdmin(),
                 ]
             ]),
@@ -146,7 +146,7 @@ class AuthenticationController
             Json::encode([
                 'user' => [
                     'id' => $user->getId(),
-                    'username' => $user->getName(),
+                    'name' => $user->getName(),
                     'isAdmin' => $user->isAdmin(),
                 ]
             ]),

--- a/src/HttpController/Api/AuthenticationController.php
+++ b/src/HttpController/Api/AuthenticationController.php
@@ -89,4 +89,19 @@ class AuthenticationController
             ]),
         );
     }
+
+    public function isAuthenticated() : Response
+    {
+        if($this->authenticationService->isUserAuthenticated()) {
+            return Response::createJson(Json::encode([
+                'authenticated' => true,
+                'userId' => $this->authenticationService->getCurrentUser()->getId(),
+                'username' => $this->authenticationService->getCurrentUser()->getName(),
+                'isAdmin' => $this->authenticationService->getCurrentUser()->isAdmin(),
+            ]));
+        }
+        return Response::createJson(Json::encode([
+            'authenticated' => false,
+        ]));
+    }
 }

--- a/src/HttpController/Api/AuthenticationController.php
+++ b/src/HttpController/Api/AuthenticationController.php
@@ -127,7 +127,7 @@ class AuthenticationController
             return Response::createBadRequest(
                 Json::encode([
                     'error' => 'MissingAuthToken',
-                    'message' => 'Authentication token is missing in both the header and the cookie'
+                    'message' => 'Authentication token header is missing'
                 ]),
                 [Header::createContentTypeJson()],
             );

--- a/tests/rest/api/authentication.assert.http
+++ b/tests/rest/api/authentication.assert.http
@@ -54,11 +54,33 @@ X-Movary-Client: RestAPI Test
         client.assert(response.status === expected, "Expected status code: " + expected);
     });
     client.test("Response has correct body", function() {
-        client.assert(response.body.hasOwnProperty("'userId'") === false, "Response body missing property: userId");
-        client.assert(response.body.hasOwnProperty("'authToken'") === false, "Response body missing property: authToken");
+        client.assert(response.body.hasOwnProperty("authToken") === true, "Response body missing property: authToken");
+        client.assert(response.body.user.hasOwnProperty("id") === true, "Response body missing property: user.id");
+        client.assert(response.body.user.hasOwnProperty("name") === true, "Response body missing property: user.name");
+        client.assert(response.body.user.hasOwnProperty("isAdmin") === true, "Response body missing property: user.isAdmin");
     });
 
     client.global.set("responseAuthToken", response.body.authToken);
+%}
+
+###
+
+GET http://127.0.0.1/api/authentication/token
+Accept: */*
+Cache-Control: no-cache
+Content-Type: application/json
+X-Auth-Token: {{responseAuthToken}}
+
+> {%
+    client.test("Response has correct status code", function() {
+        let expected = 200
+        client.assert(response.status === expected, "Expected status code: " + expected);
+    });
+    client.test("Response has correct body", function() {
+        client.assert(response.body.user.hasOwnProperty("id") === true, "Response body missing property: user.id");
+        client.assert(response.body.user.hasOwnProperty("name") === true, "Response body missing property: user.name");
+        client.assert(response.body.user.hasOwnProperty("isAdmin") === true, "Response body missing property: user.isAdmin");
+    });
 %}
 
 ###
@@ -72,6 +94,21 @@ X-Auth-Token: {{responseAuthToken}}
 > {%
     client.test("Response has correct status code", function() {
         let expected = 204
+        client.assert(response.status === expected, "Expected status code: " + expected);
+    });
+%}
+
+###
+
+GET http://127.0.0.1/api/authentication/token
+Accept: */*
+Cache-Control: no-cache
+Content-Type: application/json
+X-Auth-Token: {{responseAuthToken}}
+
+> {%
+    client.test("Response has correct status code", function() {
+        let expected = 403
         client.assert(response.status === expected, "Expected status code: " + expected);
     });
 %}

--- a/tests/rest/api/authentication.assert.http
+++ b/tests/rest/api/authentication.assert.http
@@ -108,8 +108,25 @@ X-Auth-Token: {{responseAuthToken}}
 
 > {%
     client.test("Response has correct status code", function() {
-        let expected = 403
+        let expected = 401
         client.assert(response.status === expected, "Expected status code: " + expected);
+    });
+%}
+
+###
+
+GET http://127.0.0.1/api/authentication/token
+Accept: */*
+Cache-Control: no-cache
+Content-Type: application/json
+
+> {%
+    client.test("Response has correct status code", function() {
+        let expectedStatusCode = 400
+        let expectedError = "MissingAuthToken";
+        client.assert(response.status === expectedStatusCode, "Expected status code: " + expectedStatusCode);
+        client.assert(response.body.error === expectedError, "Expected error: " + expectedError);
+        client.assert(response.body.message === 'Authentication token is missing in both the header and the cookie');
     });
 %}
 

--- a/tests/rest/api/authentication.assert.http
+++ b/tests/rest/api/authentication.assert.http
@@ -126,7 +126,7 @@ Content-Type: application/json
         let expectedError = "MissingAuthToken";
         client.assert(response.status === expectedStatusCode, "Expected status code: " + expectedStatusCode);
         client.assert(response.body.error === expectedError, "Expected error: " + expectedError);
-        client.assert(response.body.message === 'Authentication token is missing in both the header and the cookie');
+        client.assert(response.body.message === 'Authentication token header is missing');
     });
 %}
 

--- a/tests/rest/api/authentication.assert.http
+++ b/tests/rest/api/authentication.assert.http
@@ -89,7 +89,7 @@ Content-Type: application/json
         client.assert(response.status === expected, "Expected status code: " + expected);
     });
     client.test("Response has correct body", function() {
-        let expected = '{"error":"MissingAuthToken","message":"Authentication token to delete in headers missing"}';
+        let expected = '{"error":"MissingAuthToken","message":"Authentication token header is missing"}';
         client.assert(JSON.stringify(response.body) === expected, "Expected response body: " + expected);
     });
 %}

--- a/tests/rest/api/authentication.http
+++ b/tests/rest/api/authentication.http
@@ -1,4 +1,4 @@
-POST http://127.0.0.1/api/authentication/token
+POST http://127.0.0.1/api/authentication/create-token
 Accept: */*
 Cache-Control: no-cache
 Content-Type: application/json
@@ -7,3 +7,9 @@ X-Movary-Client: RestAPI Test
 {"email" : "{{email}}", "password" : "{{password}}", "rememberMe" : 1, "totpCode" : 123456}
 
 ###
+
+GET http://127.0.0.1/api/authentication/authenticated
+Accept: */*
+Cache-Control: no-cache
+Content-Type: application/json
+X-Movary-Client: RestAPI Test

--- a/tests/rest/api/authentication.http
+++ b/tests/rest/api/authentication.http
@@ -8,11 +8,11 @@ X-Movary-Client: RestAPI Test
 
 ###
 
-GET http://127.0.0.1/api/authentication/authenticated
+GET http://127.0.0.1/api/authentication/token
 Accept: */*
 Cache-Control: no-cache
 Content-Type: application/json
-X-Movary-Client: RestAPI Test
+X-Auth-Token: {{xAuthToken}}
 
 ###
 


### PR DESCRIPTION
This PR adds an API endpoint to check if the user is authenticated or not.
The path is `/authentication/authenticated` and it returns a JSON object with `authenticated = false || true`.

If the user is authenticated, the object will also include a `username` and `userId` property, with the values of the current username and ID. 

This PR is based on #575 , so it has to be merged after that one.