### PR TITLE
Add API endpoint for the dashboard data

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6,6 +6,258 @@
   },
   "servers": [],
   "paths": {
+    "\/users\/{username}\/dashboard": {
+        "get": {
+            "tags": [
+                "Dashboard"
+            ],
+            "summary": "Get all the data that's shown in the dashboard",
+            "description": "Get all the statistics and the order of the rows in the dashboard. When a row is collapsed / hidden by default, the data for the hidden row isn't sent.",
+            "parameters": [
+                {
+                    "name": "username",
+                    "in": "path",
+                    "description": "Name of user",
+                    "required": true,
+                    "schema": {
+                      "type": "string"
+                    }
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "User is allowed to see the statistics of the requested user.",
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "users": {
+                                        "type": "object",
+                                        "example": [
+                                            {
+                                                "name": "user1"
+                                            },
+                                            {
+                                                "name": "user2"
+                                            }
+                                        ]
+                                    },
+                                    "totalPlayCount": {
+                                        "$ref": "#/components/schemas/plays"
+                                    },
+                                    "uniqueMoviesCount" : {
+                                        "type": "integer",
+                                        "example": 1
+                                    },
+                                    "totalHoursWatched": {
+                                        "type": "number",
+                                        "example": 1
+                                    },
+                                    "averagePersonalRating": {
+                                        "type": "number",
+                                        "example": 1
+                                    },
+                                    "averagePlaysPerDay": {
+                                        "type": "number",
+                                        "example": 1
+                                    },
+                                    "averageRuntime": {
+                                        "type": "number",
+                                        "example": 1
+                                    },
+                                    "dashboardRows": {
+                                        "type": "array",
+                                        "description": "An array containing JSON objects of the dashboard rows. The order of the objects is the order of the rows.",
+                                        "example": [
+                                            {
+                                                "row": "Last Plays",
+                                                "id": 0,
+                                                "isExtended": true,
+                                                "isVisible": true
+                                            },
+                                            {
+                                                "row": "Latest in Watchlist",
+                                                "id": 9,
+                                                "isExtended": true,
+                                                "isVisible": true
+                                            },
+                                            {
+                                                "row": "Most watched Actors",
+                                                "id": 1,
+                                                "isExtended": false,
+                                                "isVisible": true
+                                            },
+                                            {
+                                                "row": "Most watched Actresses",
+                                                "id": 2,
+                                                "isExtended": false,
+                                                "isVisible": true
+                                            },
+                                            {
+                                                "row": "Most watched Directors",
+                                                "id": 3,
+                                                "isExtended": false,
+                                                "isVisible": true
+                                            },
+                                            {
+                                                "row": "Most watched Genres",
+                                                "id": 4,
+                                                "isExtended": false,
+                                                "isVisible": true
+                                            },
+                                            {
+                                                "row": "Most watched Languages",
+                                                "id": 8,
+                                                "isExtended": false,
+                                                "isVisible": true
+                                            },
+                                            {
+                                                "row": "Most watched Production Companies",
+                                                "id": 6,
+                                                "isExtended": false,
+                                                "isVisible": true
+                                            },
+                                            {
+                                                "row": "Most watched Release Years",
+                                                "id": 7,
+                                                "isExtended": false,
+                                                "isVisible": true
+                                            }
+                                        ]
+                                    },
+                                    "lastPlays": {
+                                        "type": "array",
+                                        "description": "An array containing JSON objects of the last played movies based on date.",
+                                        "example": [
+                                            {
+                                                "$ref": "#/components/schemas/movie"
+                                            }
+                                        ]
+                                    },
+                                    "mostWatchedActors": {
+                                        "type": "array",
+                                        "description": "An array containing JSON objects of the most watched male actors.",
+                                        "example": [
+                                            {
+                                                "id": 1,
+                                                "name": "Actor name",
+                                                "uniqueCount": 4,
+                                                "totalCount": 4,
+                                                "gender": "m",
+                                                "tmdb_poster_path": "/path_to_poster_on_tmdb.jpg",
+                                                "poster_path": "/storage/images/person/path_to_poster_on_local_storage.jpg"
+                                            }
+                                        ]
+                                    },
+                                    "mostWatchedActresses": {
+                                        "type": "array",
+                                        "description": "An array containing JSON objects of the most watched actresses.",
+                                        "example": [
+                                            {
+                                                "id": 1,
+                                                "name": "Actress name",
+                                                "uniqueCount": 2,
+                                                "totalCount": 2,
+                                                "gender": "f",
+                                                "tmdb_poster_path": "/path_to_poster_on_tmdb.jpg",
+                                                "poster_path": "/storage/images/person/path_to_poster_on_local_storage.jpg"
+                                            }
+                                        ]
+                                    },
+                                    "mostWatchedDirectors": {
+                                        "type": "array",
+                                        "description": "An array containing JSON objects of the most watched directors.",
+                                        "example": [
+                                            {
+                                                "id": 1,
+                                                "name": "Director name",
+                                                "uniqueCount": 2,
+                                                "totalCount": 2,
+                                                "gender": "m",
+                                                "tmdb_poster_path": "/path_to_poster_on_tmdb.jpg",
+                                                "poster_path": "/storage/images/person/path_to_poster_on_local_storage.jpg"
+                                            }
+                                        ]
+                                    },
+                                    "mostWatchedLanguages": {
+                                        "type": "array",
+                                        "description": "An array containing JSON objects of the most watched languages.",
+                                        "example": [
+                                            {
+                                                "language": "en",
+                                                "count": 7,
+                                                "name": "English",
+                                                "code": "en"
+                                            }
+                                        ]
+                                    },
+                                    "mostWatchedGenres": {
+                                        "type": "array",
+                                        "description": "An array containing JSON objects of the most watched genres.",
+                                        "example": [
+                                            {
+                                                "name": "Adventure",
+                                                "count": 7
+                                            },
+                                            {
+                                                "name": "Action",
+                                                "count": 6
+                                            },
+                                            {
+                                                "name": "Science Fiction",
+                                                "count": 3
+                                            },
+                                            {
+                                                "name": "Fantasy",
+                                                "count": 1
+                                            }
+                                        ]
+                                    },
+                                    "mostWatchedProductionCompanies": {
+                                        "type": "array",
+                                        "description": "An array containing JSON objects of the most watched production companies and the watched movies they produced.",
+                                        "example": [
+                                            {
+                                                "name": "Lucasfilm Ltd.",
+                                                "count": 4,
+                                                "origin_country": "US",
+                                                "movies": [
+                                                    "Indiana Jones and the Temple of Doom",
+                                                    "Raiders of the Lost Ark",
+                                                    "Indiana Jones and the Kingdom of the Crystal Skull",
+                                                    "Indiana Jones and the Last Crusade"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "mostWatchedReleaseYears": {
+                                        "type": "array",
+                                        "description": "An array containing JSON objects of the most watched release years.",
+                                        "example": [
+                                            {
+                                                "name": 2023,
+                                                "count": 1
+                                            }
+                                        ]
+                                    },
+                                    "watchlistItems": {
+                                        "type": "array",
+                                        "description": "An array containing JSON objects of the items in the watchlist.",
+                                        "example": [
+                                            {
+                                                "$ref": "#/components/schemas/movie"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
     "\/users\/{username}\/history\/movies": {
       "get": {
         "tags": [

--- a/settings/routes.php
+++ b/settings/routes.php
@@ -204,6 +204,8 @@ function addApiRoutes(RouterService $routerService, FastRoute\RouteCollector $ro
 
     $routes->add('GET', '/openapi', [Api\OpenApiController::class, 'getSchema']);
 
+    $routes->add('GET', '/users/{username:[a-zA-Z0-9]+}/dashboard', [Api\DashboardController::class, 'getDashboardData']);
+
     $routeUserHistory = '/users/{username:[a-zA-Z0-9]+}/history/movies';
     $routes->add('GET', $routeUserHistory, [Api\HistoryController::class, 'getHistory'], [Api\Middleware\IsAuthorizedToReadUserData::class]);
     $routes->add('POST', $routeUserHistory, [Api\HistoryController::class, 'addToHistory'], [Api\Middleware\IsAuthorizedToWriteUserData::class]);

--- a/src/HttpController/Api/DashboardController.php
+++ b/src/HttpController/Api/DashboardController.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types=1);
+
+namespace Movary\HttpController\Api;
+
+use Movary\Domain\Movie\History\MovieHistoryApi;
+use Movary\Domain\Movie\MovieApi;
+use Movary\Domain\Movie\Watchlist\MovieWatchlistApi;
+use Movary\Domain\User\Service\Authentication;
+use Movary\Domain\User\Service\UserPageAuthorizationChecker;
+use Movary\Domain\User\UserApi;
+use Movary\Service\Dashboard\DashboardFactory;
+use Movary\Util\Json;
+use Movary\ValueObject\Gender;
+use Movary\ValueObject\Http\Request;
+use Movary\ValueObject\Http\Response;
+
+class DashboardController
+{
+    public function __construct(
+        private readonly MovieHistoryApi $movieHistoryApi,
+        private readonly MovieApi $movieApi,
+        private readonly MovieWatchlistApi $movieWatchlistApi,
+        private readonly UserPageAuthorizationChecker $userPageAuthorizationChecker,
+        private readonly DashboardFactory $dashboardFactory,
+        private readonly UserApi $userApi,
+        private readonly Authentication $authenticationService,
+    ) {
+    }
+
+    public function getDashboardData(Request $request) : Response
+    {
+        $userId = $this->userPageAuthorizationChecker->findUserIdIfCurrentVisitorIsAllowedToSeeUser((string)$request->getRouteParameters()['username']);
+        if ($userId === null) {
+            return Response::createForbiddenRedirect($request->getPath());
+        }
+
+        $currentUserId = null;
+        if ($this->authenticationService->isUserAuthenticated() === true) {
+            $currentUserId = $this->authenticationService->getCurrentUserId();
+        }
+
+        $dashboardRows = $this->dashboardFactory->createDashboardRowsForUser($this->userApi->fetchUser($userId));
+
+        $response = [
+            'users' => $this->userPageAuthorizationChecker->fetchAllVisibleUsernamesForCurrentVisitor(),
+            'totalPlayCount' => $this->movieApi->fetchTotalPlayCount($userId),
+            'uniqueMoviesCount' => $this->movieApi->fetchTotalPlayCountUnique($userId),
+            'totalHoursWatched' => $this->movieHistoryApi->fetchTotalHoursWatched($userId),
+            'averagePersonalRating' => $this->movieHistoryApi->fetchAveragePersonalRating($userId),
+            'averagePlaysPerDay' => $this->movieHistoryApi->fetchAveragePlaysPerDay($userId),
+            'averageRuntime' => $this->movieHistoryApi->fetchAverageRuntime($userId),
+            'dashboardRows' => $dashboardRows->asArray(),
+            'lastPlays' => [],
+            'mostWatchedActors' => [],
+            'mostWatchedActresses' => [],
+            'mostWatchedDirectors' => [],
+            'mostWatchedLanguages' => [],
+            'mostWatchedGenres' => [],
+            'mostWatchedProductionCompanies' => [],
+            'mostWatchedReleaseYears' => [],
+            'watchlistItems' => [],
+        ];
+
+        foreach($dashboardRows as $row) {
+            if($row->isExtended()) {
+                if($row->isLastPlays()) {
+                    $response['lastPlays'] = $this->movieHistoryApi->fetchLastPlays($userId);
+                } else if($row->isMostWatchedActors()) {
+                    $response['mostWatchedActors'] = $this->movieHistoryApi->fetchActors($userId, 6, 1, gender: Gender::createMale(), personFilterUserId: $currentUserId);
+                } else if($row->isMostWatchedActresses()) {
+                    $response['mostWatchedActresses'] = $this->movieHistoryApi->fetchActors($userId, 6, 1, gender: Gender::createFemale(), personFilterUserId: $currentUserId);
+                } else if($row->isMostWatchedDirectors()) {
+                    $response['mostWatchedDirectors'] = $this->movieHistoryApi->fetchDirectors($userId, 6, 1, personFilterUserId: $currentUserId);
+                } else if($row->isMostWatchedLanguages()) {
+                    $response['mostWatchedLanguages'] = $this->movieHistoryApi->fetchMostWatchedLanguages($userId);
+                } else if($row->isMostWatchedGenres()) {
+                    $response['mostWatchedGenres'] = $this->movieHistoryApi->fetchMostWatchedGenres($userId);
+                } else if($row->isMostWatchedProductionCompanies()) {
+                    $response['mostWatchedProductionCompanies'] = $this->movieHistoryApi->fetchMostWatchedProductionCompanies($userId, 12);
+                } else if($row->isMostWatchedReleaseYears()) {
+                    $response['mostWatchedReleaseYears'] = $this->movieHistoryApi->fetchMostWatchedReleaseYears($userId);
+                } else if($row->isWatchlist()) {
+                    $response['watchlistItems'] = $this->movieWatchlistApi->fetchWatchlistPaginated($userId, 6, 1);
+                }
+            }
+        }
+        return Response::createJson(Json::encode($response));
+    }
+}

--- a/src/Service/Dashboard/Dto/DashboardRowList.php
+++ b/src/Service/Dashboard/Dto/DashboardRowList.php
@@ -34,4 +34,22 @@ class DashboardRowList extends AbstractList
 
         ksort($this->data);
     }
+
+    public function asArray() : array
+    {
+        $serialized = [];
+        /**
+         * @var $row DashboardRow
+         * @var $this->data array
+         */
+        foreach($this->data as $row) {
+            array_push($serialized, [
+                'row' => $row->getName(),
+                'id' => $row->getId(),
+                'isExtended' => $row->isExtended(),
+                'isVisible' => $row->isVisible()
+            ]);
+        }
+        return $serialized;
+    }
 }


### PR DESCRIPTION
This PR adds an endpoint which returns all the data that's shown in the dashboard.
Additionally, it also returns the dashboard rows and their properties (e.g. whether they're extended)

If the row is hidden, then the data for that row won't be included in the API response. The new Vue frontend will hide / collapse that row and if the user clicks on it, the client manually requests the data for the row. This adds lazy loading support for the dashboard row, (partially?) fixing #394