### PR TITLE
Add API endpoint for destroying tokens

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1151,6 +1151,31 @@
             "$ref": "#/components/responses/401"
           }
         }
+      },
+      "delete" : {
+        "tags": [
+          "Authentication"
+        ],
+        "description": "Delete the authentication token provided in the X-Auth-Token header value.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Auth-Token",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "requestBody": {},
+        "responses": {
+          "204": {
+            "description": "Returned if authentication token does no longer exist"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          }
+        }
       }
     }
   },

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -498,3 +498,11 @@ function addAlert(parentDivId, message, color, withCloseButton = true, marginBot
 function removeAlert(parentDivId) {
     document.getElementById(parentDivId).innerHTML = ''
 }
+
+async function logout() {
+    await fetch('/api/authentication/token', {
+        method: 'DELETE',
+    });
+
+    window.location.href = '/'
+}

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -11,6 +11,11 @@ async function submitCredentials() {
         return;
     }
 
+    const forbiddenPageAlert = document.getElementById('forbiddenPageAlert');
+    if (forbiddenPageAlert) {
+        forbiddenPageAlert.classList.add('d-none');
+    }
+
     if (response.status === 400) {
         const error = await response.json();
 

--- a/settings/routes.php
+++ b/settings/routes.php
@@ -203,6 +203,7 @@ function addApiRoutes(RouterService $routerService, FastRoute\RouteCollector $ro
 
     $routes->add('GET', '/openapi', [Api\OpenApiController::class, 'getSchema']);
     $routes->add('POST', '/authentication/create-token', [Api\AuthenticationController::class, 'createToken']);
+    $routes->add("GET", '/authentication/destroy-token', [Api\AuthenticationController::class, 'destroyToken'], [Api\Middleware\IsAuthenticated::class]);
 
     $routeUserHistory = '/users/{username:[a-zA-Z0-9]+}/history/movies';
     $routes->add('GET', $routeUserHistory, [Api\HistoryController::class, 'getHistory'], [Api\Middleware\IsAuthorizedToReadUserData::class]);

--- a/settings/routes.php
+++ b/settings/routes.php
@@ -19,8 +19,6 @@ function addWebRoutes(RouterService $routerService, FastRoute\RouteCollector $ro
 
     $routes->add('GET', '/', [Web\LandingPageController::class, 'render'], [Web\Middleware\UserIsUnauthenticated::class, Web\Middleware\ServerHasNoUsers::class]);
     $routes->add('GET', '/login', [Web\AuthenticationController::class, 'renderLoginPage'], [Web\Middleware\UserIsUnauthenticated::class]);
-    $routes->add('POST', '/login', [Web\AuthenticationController::class, 'login']);
-    $routes->add('GET', '/logout', [Web\AuthenticationController::class, 'logout']);
     $routes->add('POST', '/create-user', [Web\CreateUserController::class, 'createUser'], [
         Web\Middleware\UserIsUnauthenticated::class,
         Web\Middleware\ServerHasUsers::class,
@@ -203,7 +201,7 @@ function addApiRoutes(RouterService $routerService, FastRoute\RouteCollector $ro
 
     $routes->add('GET', '/openapi', [Api\OpenApiController::class, 'getSchema']);
     $routes->add('POST', '/authentication/token', [Api\AuthenticationController::class, 'createToken']);
-    $routes->add('DELETE', '/authentication/token', [Api\AuthenticationController::class, 'destroyToken'], [Api\Middleware\IsAuthenticated::class]);
+    $routes->add('DELETE', '/authentication/token', [Api\AuthenticationController::class, 'destroyToken']);
 
     $routeUserHistory = '/users/{username:[a-zA-Z0-9]+}/history/movies';
     $routes->add('GET', $routeUserHistory, [Api\HistoryController::class, 'getHistory'], [Api\Middleware\IsAuthorizedToReadUserData::class]);

--- a/settings/routes.php
+++ b/settings/routes.php
@@ -203,7 +203,7 @@ function addApiRoutes(RouterService $routerService, FastRoute\RouteCollector $ro
 
     $routes->add('GET', '/openapi', [Api\OpenApiController::class, 'getSchema']);
     $routes->add('POST', '/authentication/token', [Api\AuthenticationController::class, 'createToken']);
-    $routes->add("DELETE", '/authentication/token', [Api\AuthenticationController::class, 'destroyToken'], [Api\Middleware\IsAuthenticated::class]);
+    $routes->add('DELETE', '/authentication/token', [Api\AuthenticationController::class, 'destroyToken'], [Api\Middleware\IsAuthenticated::class]);
 
     $routeUserHistory = '/users/{username:[a-zA-Z0-9]+}/history/movies';
     $routes->add('GET', $routeUserHistory, [Api\HistoryController::class, 'getHistory'], [Api\Middleware\IsAuthorizedToReadUserData::class]);

--- a/src/Domain/User/Service/Authentication.php
+++ b/src/Domain/User/Service/Authentication.php
@@ -113,7 +113,7 @@ class Authentication
         return $this->userApi->findByToken($apiToken)?->getId();
     }
 
-    public function isUserAuthenticated() : bool
+    public function isUserAuthenticatedWithCookie() : bool
     {
         $token = filter_input(INPUT_COOKIE, self::AUTHENTICATION_COOKIE_NAME);
 
@@ -152,11 +152,11 @@ class Authentication
             return true;
         }
 
-        if ($privacyLevel === 1 && $this->isUserAuthenticated() === true) {
+        if ($privacyLevel === 1 && $this->isUserAuthenticatedWithCookie() === true) {
             return true;
         }
 
-        return $this->isUserAuthenticated() === true && $this->getCurrentUserId() === $userId;
+        return $this->isUserAuthenticatedWithCookie() === true && $this->getCurrentUserId() === $userId;
     }
 
     public function isValidToken(string $token) : bool

--- a/src/Domain/User/Service/UserPageAuthorizationChecker.php
+++ b/src/Domain/User/Service/UserPageAuthorizationChecker.php
@@ -15,7 +15,7 @@ class UserPageAuthorizationChecker
 
     public function fetchAllHavingWatchedMovieVisibleUsernamesForCurrentVisitor(int $movieId) : array
     {
-        if ($this->authenticationService->isUserAuthenticated() === false) {
+        if ($this->authenticationService->isUserAuthenticatedWithCookie() === false) {
             return $this->userApi->fetchAllHavingWatchedMoviePublicVisibleUsernames($movieId);
         }
 
@@ -24,7 +24,7 @@ class UserPageAuthorizationChecker
 
     public function fetchAllHavingWatchedMovieWithPersonVisibleUsernamesForCurrentVisitor(int $personId) : array
     {
-        if ($this->authenticationService->isUserAuthenticated() === false) {
+        if ($this->authenticationService->isUserAuthenticatedWithCookie() === false) {
             return $this->userApi->fetchAllHavingWatchedMovieWithPersonPublicVisibleUsernames($personId);
         }
 
@@ -33,7 +33,7 @@ class UserPageAuthorizationChecker
 
     public function fetchAllVisibleUsernamesForCurrentVisitor() : array
     {
-        if ($this->authenticationService->isUserAuthenticated() === false) {
+        if ($this->authenticationService->isUserAuthenticatedWithCookie() === false) {
             return $this->userApi->fetchAllPublicVisibleUsernames();
         }
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -279,7 +279,7 @@ class Factory
         $currentRequest = $container->get(Request::class);
         $routeUsername = $currentRequest->getRouteParameters()['username'] ?? null;
 
-        $userAuthenticated = $container->get(Authentication::class)->isUserAuthenticated();
+        $userAuthenticated = $container->get(Authentication::class)->isUserAuthenticatedWithCookie();
 
         $twig->addGlobal('loggedIn', $userAuthenticated);
 

--- a/src/HttpController/Api/AuthenticationController.php
+++ b/src/HttpController/Api/AuthenticationController.php
@@ -84,7 +84,11 @@ class AuthenticationController
             $this->authenticationService->logout();
         } 
         else {
-            $this->userApi->deleteApiToken($this->authenticationService->getUserIdByApiToken($request));
+            $apiToken = $this->authenticationService->getUserIdByApiToken($request);
+            if($apiToken === null) {
+                return Response::createForbidden();
+            }
+            $this->userApi->deleteApiToken($apiToken);
         }
         return Response::createOk();
     }

--- a/src/HttpController/Api/AuthenticationController.php
+++ b/src/HttpController/Api/AuthenticationController.php
@@ -23,7 +23,7 @@ class AuthenticationController
     {
         $tokenRequestBody = Json::decode($request->getBody());
 
-        if ($tokenRequestBody['email'] === null || $tokenRequestBody['password'] === null) {
+        if (isset($tokenRequestBody['email']) === false || isset($tokenRequestBody['password']) === false) {
             return Response::createBadRequest(
                 Json::encode([
                     'error' => 'MissingCredentials',

--- a/src/HttpController/Api/AuthenticationController.php
+++ b/src/HttpController/Api/AuthenticationController.php
@@ -77,4 +77,15 @@ class AuthenticationController
 
         return Response::createSeeOther($targetRelativeUrl);
     }
+
+    public function destroyToken(Request $request) : Response
+    {
+        if($this->authenticationService->isUserAuthenticated() === true) {
+            $this->authenticationService->logout();
+        } 
+        else {
+            $this->userApi->deleteApiToken($this->authenticationService->getUserIdByApiToken($request));
+        }
+        return Response::createOk();
+    }
 }

--- a/src/HttpController/Api/AuthenticationController.php
+++ b/src/HttpController/Api/AuthenticationController.php
@@ -6,6 +6,7 @@ use Movary\Domain\User\Exception\InvalidCredentials;
 use Movary\Domain\User\Exception\InvalidTotpCode;
 use Movary\Domain\User\Exception\MissingTotpCode;
 use Movary\Domain\User\Service\Authentication;
+use Movary\Domain\User\UserApi;
 use Movary\Util\Json;
 use Movary\ValueObject\Http\Header;
 use Movary\ValueObject\Http\Request;
@@ -15,6 +16,7 @@ class AuthenticationController
 {
     public function __construct(
         private readonly Authentication $authenticationService,
+        private readonly UserApi $userApi
     ) {
     }
 
@@ -102,6 +104,6 @@ class AuthenticationController
             }
             $this->userApi->deleteApiToken($apiToken);
         }
-        return Response::createOk();
+        return Response::CreateNoContent();
     }
 }

--- a/src/HttpController/Web/ActorsController.php
+++ b/src/HttpController/Web/ActorsController.php
@@ -34,7 +34,7 @@ class ActorsController
         $requestData = $this->requestMapper->mapRenderPageRequest($request);
 
         $currentUserId = null;
-        if ($this->authenticationService->isUserAuthenticated() === true) {
+        if ($this->authenticationService->isUserAuthenticatedWithCookie() === true) {
             $currentUserId = $this->authenticationService->getCurrentUserId();
         }
 

--- a/src/HttpController/Web/AuthenticationController.php
+++ b/src/HttpController/Web/AuthenticationController.php
@@ -3,12 +3,7 @@
 namespace Movary\HttpController\Web;
 
 use Movary\Domain\SessionService;
-use Movary\Domain\User\Exception\InvalidCredentials;
-use Movary\Domain\User\Exception\InvalidTotpCode;
-use Movary\Domain\User\Exception\MissingTotpCode;
-use Movary\Domain\User\Service;
 use Movary\Util\SessionWrapper;
-use Movary\ValueObject\Http\Header;
 use Movary\ValueObject\Http\Request;
 use Movary\ValueObject\Http\Response;
 use Movary\ValueObject\Http\StatusCode;
@@ -18,20 +13,8 @@ class AuthenticationController
 {
     public function __construct(
         private readonly Environment $twig,
-        private readonly Service\Authentication $authenticationService,
         private readonly SessionWrapper $sessionWrapper,
     ) {
-    }
-
-    public function logout() : Response
-    {
-        $this->authenticationService->logout();
-
-        return Response::create(
-            StatusCode::createSeeOther(),
-            null,
-            [Header::createLocation('/')],
-        );
     }
 
     public function renderLoginPage(Request $request) : Response

--- a/src/HttpController/Web/DashboardController.php
+++ b/src/HttpController/Web/DashboardController.php
@@ -37,7 +37,7 @@ class DashboardController
         }
 
         $currentUserId = null;
-        if ($this->authenticationService->isUserAuthenticated() === true) {
+        if ($this->authenticationService->isUserAuthenticatedWithCookie() === true) {
             $currentUserId = $this->authenticationService->getCurrentUserId();
         }
 

--- a/src/HttpController/Web/DirectorsController.php
+++ b/src/HttpController/Web/DirectorsController.php
@@ -34,7 +34,7 @@ class DirectorsController
         $requestData = $this->requestMapper->mapRenderPageRequest($request);
 
         $currentUserId = null;
-        if ($this->authenticationService->isUserAuthenticated() === true) {
+        if ($this->authenticationService->isUserAuthenticatedWithCookie() === true) {
             $currentUserId = $this->authenticationService->getCurrentUserId();
         }
 

--- a/src/HttpController/Web/Middleware/UserIsAuthenticated.php
+++ b/src/HttpController/Web/Middleware/UserIsAuthenticated.php
@@ -14,7 +14,7 @@ class UserIsAuthenticated implements MiddlewareInterface
 
     public function __invoke() : ?Response
     {
-        if ($this->authenticationService->isUserAuthenticated() === true) {
+        if ($this->authenticationService->isUserAuthenticatedWithCookie() === true) {
             return null;
         }
 

--- a/src/HttpController/Web/Middleware/UserIsUnauthenticated.php
+++ b/src/HttpController/Web/Middleware/UserIsUnauthenticated.php
@@ -14,7 +14,7 @@ class UserIsUnauthenticated implements MiddlewareInterface
 
     public function __invoke() : ?Response
     {
-        if ($this->authenticationService->isUserAuthenticated() === false) {
+        if ($this->authenticationService->isUserAuthenticatedWithCookie() === false) {
             return null;
         }
 

--- a/src/HttpController/Web/Movie/MovieController.php
+++ b/src/HttpController/Web/Movie/MovieController.php
@@ -69,7 +69,7 @@ class MovieController
         }
 
         $currentUser = null;
-        if ($this->authenticationService->isUserAuthenticated() === true) {
+        if ($this->authenticationService->isUserAuthenticatedWithCookie() === true) {
             $currentUser = $this->authenticationService->getCurrentUser();
         }
 

--- a/src/HttpController/Web/PersonController.php
+++ b/src/HttpController/Web/PersonController.php
@@ -98,7 +98,7 @@ class PersonController
         }
 
         $isHiddenInTopLists = false;
-        if ($this->authenticationService->isUserAuthenticated() === true) {
+        if ($this->authenticationService->isUserAuthenticatedWithCookie() === true) {
             $userId = $this->authenticationService->getCurrentUserId();
             $isHiddenInTopLists = $this->userApi->hasHiddenPerson($userId, $personId);
         }

--- a/src/HttpController/Web/UserController.php
+++ b/src/HttpController/Web/UserController.php
@@ -22,7 +22,7 @@ class UserController
 
     public function createUser(Request $request) : Response
     {
-        if ($this->authenticationService->isUserAuthenticated() === false
+        if ($this->authenticationService->isUserAuthenticatedWithCookie() === false
             && $this->authenticationService->getCurrentUser()->isAdmin() === false) {
             return Response::createForbidden();
         }
@@ -65,7 +65,7 @@ class UserController
 
     public function fetchUsers() : Response
     {
-        if ($this->authenticationService->isUserAuthenticated() === false
+        if ($this->authenticationService->isUserAuthenticatedWithCookie() === false
             && $this->authenticationService->getCurrentUser()->isAdmin() === false) {
             return Response::createForbidden();
         }

--- a/templates/component/navbar.html.twig
+++ b/templates/component/navbar.html.twig
@@ -48,7 +48,7 @@
                 </li>
                 {% if loggedIn == true %}
                     <li><a class="dropdown-item {% if requestUrlPath starts with '/settings/' %}active{% endif %}" href="/settings/account/general">Settings</a></li>
-                    <li><a class="dropdown-item" href="/logout">Logout</a></li>
+                    <li><button class="dropdown-item" onclick="logout()" style="cursor: pointer">Logout</button></li>
                 {% else %}
                     <li><a class="dropdown-item" href="/login">Login</a></li>
                 {% endif %}

--- a/templates/page/login.html.twig
+++ b/templates/page/login.html.twig
@@ -44,7 +44,7 @@
                     </div>
                 {% endif %}
                 {% if redirect != false %}
-                    <div class="alert alert-danger" role="alert" style="margin-bottom: 0.7rem!important;">
+                    <div class="alert alert-danger" role="alert" id="forbiddenPageAlert">
                         Sign in to access page
                     </div>
                     <input type="hidden" value="{{ redirect }}" name="redirect" />

--- a/tests/rest/api/authentication.assert.http
+++ b/tests/rest/api/authentication.assert.http
@@ -1,0 +1,97 @@
+POST http://127.0.0.1/api/authentication/token
+Accept: */*
+Cache-Control: no-cache
+Content-Type: application/json
+X-Movary-Client: RestAPI Test
+
+{}
+
+> {%
+    client.test("Response has correct status code", function() {
+        let expected = 400
+        client.assert(response.status === expected, "Expected status code: " + expected);
+    });
+    client.test("Response has correct body", function() {
+        let expected = '{"error":"MissingCredentials","message":"Email or password is missing"}';
+        client.assert(JSON.stringify(response.body) === expected, "Expected response body: " + expected);
+    });
+%}
+
+###
+
+POST http://127.0.0.1/api/authentication/token
+Accept: */*
+Cache-Control: no-cache
+Content-Type: application/json
+X-Movary-Client: RestAPI Test
+
+{"email" : "wrongEmail", "password" : "wrongPassword"}
+
+> {%
+    client.test("Response has correct status code", function() {
+        let expected = 401
+        client.assert(response.status === expected, "Expected status code: " + expected);
+    });
+    client.test("Response has correct body", function() {
+        let expected = '{"error":"InvalidCredentials","message":"Invalid credentials"}';
+        client.assert(JSON.stringify(response.body) === expected, "Expected response body: " + expected);
+    });
+%}
+
+###
+
+POST http://127.0.0.1/api/authentication/token
+Accept: */*
+Cache-Control: no-cache
+Content-Type: application/json
+X-Movary-Client: RestAPI Test
+
+{"email" : "{{email}}", "password" : "{{password}}"}
+
+> {%
+    client.test("Response has correct status code", function() {
+        let expected = 200
+        client.assert(response.status === expected, "Expected status code: " + expected);
+    });
+    client.test("Response has correct body", function() {
+        client.assert(response.body.hasOwnProperty("'userId'") === false, "Response body missing property: userId");
+        client.assert(response.body.hasOwnProperty("'authToken'") === false, "Response body missing property: authToken");
+    });
+
+    client.global.set("responseAuthToken", response.body.authToken);
+%}
+
+###
+
+DELETE http://127.0.0.1/api/authentication/token
+Accept: */*
+Cache-Control: no-cache
+Content-Type: application/json
+X-Auth-Token: {{responseAuthToken}}
+
+> {%
+    client.test("Response has correct status code", function() {
+        let expected = 204
+        client.assert(response.status === expected, "Expected status code: " + expected);
+    });
+%}
+
+###
+
+DELETE http://127.0.0.1/api/authentication/token
+Accept: */*
+Cache-Control: no-cache
+Content-Type: application/json
+
+> {%
+    client.test("Response has correct status code", function() {
+        let expected = 400
+        client.assert(response.status === expected, "Expected status code: " + expected);
+    });
+    client.test("Response has correct body", function() {
+        let expected = '{"error":"MissingAuthToken","message":"Authentication token to delete in headers missing"}';
+        client.assert(JSON.stringify(response.body) === expected, "Expected response body: " + expected);
+    });
+%}
+
+###

--- a/tests/rest/api/authentication.http
+++ b/tests/rest/api/authentication.http
@@ -4,11 +4,11 @@ Cache-Control: no-cache
 Content-Type: application/json
 X-Movary-Client: RestAPI Test
 
-{"email" : "{{username}}", "password" : "{{password}}", "rememberMe" : 1, "totpCode" : 123456}
+{"email" : "{{email}}", "password" : "{{password}}", "rememberMe" : 1, "totpCode" : 123456}
 
 ###
 
-GET http://127.0.0.1/api/authentication/destroy-token
+DELETE http://127.0.0.1/api/authentication/token
 Accept: */*
 Cache-Control: no-cache
 Content-Type: application/json

--- a/tests/rest/api/authentication.http
+++ b/tests/rest/api/authentication.http
@@ -4,6 +4,13 @@ Cache-Control: no-cache
 Content-Type: application/json
 X-Movary-Client: RestAPI Test
 
-{"email" : "{{email}}", "password" : "{{password}}", "rememberMe" : 1, "totpCode" : 123456}
+{"email" : "{{username}}", "password" : "{{password}}", "rememberMe" : 1, "totpCode" : 123456}
 
 ###
+
+GET http://127.0.0.1/api/authentication/destroy-token
+Accept: */*
+Cache-Control: no-cache
+Content-Type: application/json
+X-Movary-Client: RestAPI Test
+X-Auth-Token: {{xAuthToken}}

--- a/tests/rest/api/http-client.env.json
+++ b/tests/rest/api/http-client.env.json
@@ -1,6 +1,8 @@
 {
   "testUser": {
     "username": "testUser",
-    "xAuthToken": "4f0fbe93e2752932e5700e14ffa49f67"
+    "xAuthToken": "4f0fbe93e2752932e5700e14ffa49f67",
+    "email": "testUser@domain.com",
+    "password": "password1234"
   }
 }


### PR DESCRIPTION
This PR adds an API endpoint that can destroy API tokens (manually generated by the user in the settings) and authentication tokens (generated upon login of the user).

Also important to mention that this PR is based on #575 , so that PR has to be merged before this one.