### PR TITLE
Add API endpoint for images

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -10,6 +10,7 @@ $builder->addDefinitions(
         \Movary\ValueObject\Config::class => DI\factory([Factory::class, 'createConfig']),
         \Movary\Api\Trakt\TraktApi::class => DI\factory([Factory::class, 'createTraktApi']),
         \Movary\Service\ImageCacheService::class => DI\factory([Factory::class, 'createImageCacheService']),
+        \Movary\HttpController\Api\ImagesController::class => DI\factory([Factory::class, 'createImagesController']),
         \Movary\JobQueue\JobQueueScheduler::class => DI\factory([Factory::class, 'createJobQueueScheduler']),
         \Movary\Api\Tmdb\TmdbClient::class => DI\factory([Factory::class, 'createTmdbApiClient']),
         \Movary\Service\UrlGenerator::class => DI\factory([Factory::class, 'createUrlGenerator']),

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1066,6 +1066,80 @@
         }
       }
     },
+    "/images/person/{id}": {
+      "get": {
+        "tags": [
+          "Images"
+        ],
+        "summary": "Get person image.",
+        "description": "Get image of an actor, actress or directory based on their Movary ID.",
+        "parameters": [
+          {
+            "name": "ID",
+            "in": "path",
+            "description": "ID of the person in Movary",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Person was found and has an image in Movary.",
+            "content": {
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Either no person exists with the given ID or the person exists, but doesn't have an image in Movary."
+          }
+        }
+      }
+    },
+    "/images/movie/{id}": {
+      "get": {
+        "tags": [
+          "Images"
+        ],
+        "summary": "Get movie cover image.",
+        "description": "Get cover image of a movie based on their Movary ID.",
+        "parameters": [
+          {
+            "name": "ID",
+            "in": "path",
+            "description": "ID of the movie in Movary",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Movie was found and has a cover in Movary.",
+            "content": {
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Either no movie exists with the given ID or the movie exists, but doesn't have a cover image in Movary."
+          }
+        }
+      }
+    },
     "/authentication/token": {
       "post": {
         "tags": [

--- a/settings/routes.php
+++ b/settings/routes.php
@@ -229,5 +229,8 @@ function addApiRoutes(RouterService $routerService, FastRoute\RouteCollector $ro
 
     $routes->add('GET', '/feed/radarr/{id:.+}', [Api\RadarrController::class, 'renderRadarrFeed']);
 
+    $routes->add('GET', '/images/movies/{id:\d+}', [Api\ImagesController::class, 'getMovieImage']);
+    $routes->add('GET', '/images/person/{id:\d+}', [Api\ImagesController::class, 'getPersonImage']);
+
     $routerService->addRoutesToRouteCollector($routeCollector, $routes);
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -17,9 +17,11 @@ use Movary\Command;
 use Movary\Command\CreatePublicStorageLink;
 use Movary\Domain\Movie\MovieApi;
 use Movary\Domain\Movie\Watchlist\MovieWatchlistApi;
+use Movary\Domain\Person\PersonApi;
 use Movary\Domain\User;
 use Movary\Domain\User\Service\Authentication;
 use Movary\Domain\User\UserApi;
+use Movary\HttpController\Api\ImagesController;
 use Movary\HttpController\Api\OpenApiController;
 use Movary\HttpController\Web\CreateUserController;
 use Movary\HttpController\Web\JobController;
@@ -181,6 +183,15 @@ class Factory
             $container->get(DBAL\Connection::class),
             self::createDirectoryAppRoot() . 'public/',
             '/storage/images/',
+        );
+    }
+
+    public static function createImagesController(ContainerInterface $container) : ImagesController
+    {
+        return new ImagesController(
+            $container->get(PersonApi::class),
+            $container->get(MovieApi::class),
+            self::createDirectoryAppRoot() . 'public'
         );
     }
 

--- a/src/HttpController/Api/ImagesController.php
+++ b/src/HttpController/Api/ImagesController.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace Movary\HttpController\Api;
+
+use Movary\Domain\Movie\MovieApi;
+use Movary\Domain\Person\PersonApi;
+use Movary\ValueObject\Http\Request;
+use Movary\ValueObject\Http\Response;
+
+readonly class ImagesController
+{
+    public function __construct(
+        private PersonApi $personApi,
+        private MovieApi $movieApi,
+        private string $publicDirectory
+    ){}
+
+    public function getMovieImage(Request $request) : Response
+    {
+        $resourceId = (int)$request->getRouteParameters()['id'];
+        $movie = $this->movieApi->findById($resourceId);
+        if($movie === null) {
+            return Response::createNotFound();
+        }
+        $posterPath = $movie->getPosterPath();
+        if($posterPath === null) {
+            return Response::createNotFound();
+        }
+        $image = file_get_contents($this->publicDirectory . $posterPath);
+        if($image === false) {
+            return Response::createNotFound();
+        }
+        return Response::createJpeg($image);
+    }
+
+    public function getPersonImage(Request $request) : Response
+    {
+        $resourceId = (int)$request->getRouteParameters()['id'];
+        $person = $this->personApi->findById($resourceId);
+        if($person === null) {
+            return Response::createNotFound();
+        }
+        $posterPath = $person->getPosterPath();
+        if($posterPath === null) {
+            return Response::createNotFound();
+        }
+        $image = file_get_contents($this->publicDirectory . $posterPath);
+        if($image === false) {
+            return Response::createNotFound();
+        }
+        return Response::createJpeg($image);
+    }
+}

--- a/src/ValueObject/Http/Header.php
+++ b/src/ValueObject/Http/Header.php
@@ -20,6 +20,14 @@ class Header
         return new self('Content-Type', 'application/json');
     }
 
+    public static function createContentTypeJpeg(int $contentLength) : array
+    {
+        return [
+            new self('Content-Type', 'image/jpeg'),
+            new self('Content-Length', (string)$contentLength)
+        ];
+    }
+
     public static function createLocation(string $value) : self
     {
         return new self('Location', $value);

--- a/src/ValueObject/Http/Response.php
+++ b/src/ValueObject/Http/Response.php
@@ -40,6 +40,11 @@ class Response
         return new self(StatusCode::createForbidden(), null, [Header::createLocation('/login?redirect='.$query)]);
     }
 
+    public static function createJpeg(string $image) : self
+    {
+        return new self(StatusCode::createOk(), $image, Header::createContentTypeJpeg(strlen($image)));
+    }
+
     public static function createJson(string $body, StatusCode $statusCode = null) : self
     {
         return new self($statusCode ?? StatusCode::createOk(), $body, [Header::createContentTypeJson()]);

--- a/tests/rest/api/image.http
+++ b/tests/rest/api/image.http
@@ -1,0 +1,26 @@
+GET http://127.0.0.1/api/images/person/1
+Accept: */*
+Cache-Control: no-cache
+Content-Type: application/json
+
+###
+
+GET http://127.0.0.1/api/images/movies/1
+Accept: */*
+Cache-Control: no-cache
+Content-Type: application/json
+
+###
+
+GET http://127.0.0.1/api/images/invalidresourcetype/1
+Accept: */*
+Cache-Control: no-cache
+Content-Type: application/json
+
+###
+
+GET http://127.0.0.1/api/images/person/invalidresourceid
+Accept: */*
+Cache-Control: no-cache
+Content-Type: application/json
+


### PR DESCRIPTION
I have added two API endpoints:

- `/api/images/movies/{id}`
- `/api/images/person/{id}`

They return a 404 if the ID doesn't exist or if the item doesn't have an image. If the image does exist, then it returns 200 with the raw image data attached in the body.