### PR TITLE
Centralize authentication process

### DIFF
--- a/src/HttpController/Api/AuthenticationController.php
+++ b/src/HttpController/Api/AuthenticationController.php
@@ -138,7 +138,7 @@ class AuthenticationController
             return Response::createUnauthorized();
         }
 
-        if ($this->authenticationService->isUserAuthenticatedWithCookie() && $this->authenticationService->isValidAuthToken($token) === false) {
+        if($this->authenticationService->isUserAuthenticatedWithCookie() && $this->authenticationService->isValidToken($token) === false) {
             return Response::createUnauthorized();
         }
 

--- a/src/HttpController/Api/ValueObject/AuthenticationObject.php
+++ b/src/HttpController/Api/ValueObject/AuthenticationObject.php
@@ -11,12 +11,12 @@ class AuthenticationObject
     public function __construct(
         public readonly string $token,
         public readonly int $authenticationMethod,
-        public readonly UserEntity $userId,
+        public readonly UserEntity $user,
     ) { }
 
-    public static function createAuthenticationObject(string $token, int $authenticationMethod, UserEntity $userId) : self
+    public static function createAuthenticationObject(string $token, int $authenticationMethod, UserEntity $user) : self
     {
-        return new self($token, $authenticationMethod, $userId);
+        return new self($token, $authenticationMethod, $user);
     }
 
     public function getToken() : string
@@ -31,7 +31,7 @@ class AuthenticationObject
 
     public function getUser() : UserEntity
     {
-        return $this->userId;
+        return $this->user;
     }
 
     public function hasCookieAuthentication() : bool

--- a/src/HttpController/Api/ValueObject/AuthenticationObject.php
+++ b/src/HttpController/Api/ValueObject/AuthenticationObject.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Movary\HttpController\Api\ValueObject;
+
+use Movary\Domain\User\UserEntity;
+
+class AuthenticationObject
+{
+    public const INT COOKIE_AUTHENTICATION = 1;
+    public const INT HEADER_AUTHENTICATION = 2;
+    public function __construct(
+        public readonly string $token,
+        public readonly int $authenticationMethod,
+        public readonly UserEntity $userId,
+    ) { }
+
+    public static function createAuthenticationObject(string $token, int $authenticationMethod, UserEntity $userId) : self
+    {
+        return new self($token, $authenticationMethod, $userId);
+    }
+
+    public function getToken() : string
+    {
+        return $this->token;
+    }
+
+    public function getAuthenticationMethod() : int
+    {
+        return $this->authenticationMethod;
+    }
+
+    public function getUser() : UserEntity
+    {
+        return $this->userId;
+    }
+
+    public function hasCookieAuthentication() : bool
+    {
+        return $this->authenticationMethod === self::COOKIE_AUTHENTICATION;
+    }
+
+    public function hasHeaderAuthentication() : bool
+    {
+        return $this->authenticationMethod === self::HEADER_AUTHENTICATION;
+    }
+}


### PR DESCRIPTION
In this PR I have attempted to centralize the authentication process by creating a new ValueObject called `AuthenticationObject`. 

This object has three properties, namely the token itself, the authentication method and the `userEntity` of the authenticated user.

Three new methods have been created to create this new authentication object. One method for creating the object with cookie authentication, one method for creating it with the token stored inside the `X-Movary-Token` header and one 'dynamic' method to create the object with either the header or the cookie. So the dynamic method first checks the HTTP header for the token and if it doesn't exist, it'll check the cookie for the token. 