### PR TITLE
Don't convert `$watchDate` to string during diary import

### DIFF
--- a/src/Service/Letterboxd/LetterboxdImportDiary.php
+++ b/src/Service/Letterboxd/LetterboxdImportDiary.php
@@ -86,7 +86,6 @@ class LetterboxdImportDiary
             $movie = $this->movieApi->fetchById($movieId);
 
             foreach ($watchDateToPlaysMap as $watchDate => $plays) {
-                $watchDate = Date::createFromString($watchDate);
 
                 if ($this->movieApi->findHistoryEntryForMovieByUserOnDate($movieId, $userId, $watchDate) !== null) {
                     $this->logger->info('Letterboxd import: Ignoring movie watch date because it was already set for movie: ' . $movie->getTitle());


### PR DESCRIPTION
It seems that at some point in `src/Service/Trakt/WatchDateToPlaysMap.php` the associative array was changed from using strings to Date objects as the key. There no longer needs to be a conversion from string to date within `updateWatchDates`. Prior to this change, imports from Letterboxd were failing.

These were the logs I was getting while doing an import:
```
PHP Fatal error:  Uncaught TypeError: Movary\ValueObject\Date::createFromString(): Argument #1 ($dateString) >
May 13 21:54:17 nixos movary[3443489]: Stack trace:
May 13 21:54:17 nixos movary[3443489]: #0 /app/src/Service/Letterboxd/LetterboxdImportDiary.php(89): Movary\ValueObject\Date::createFromString()
May 13 21:54:17 nixos movary[3443489]: #1 /app/src/Service/Letterboxd/LetterboxdImportDiary.php(42): Movary\Service\Letterboxd\LetterboxdImportDiary>
May 13 21:54:17 nixos movary[3443489]: #2 /app/src/Service/Letterboxd/LetterboxdImportDiary.php(54): Movary\Service\Letterboxd\LetterboxdImportDiary>
May 13 21:54:17 nixos movary[3443489]: #3 /app/src/Service/JobProcessor.php(33): Movary\Service\Letterboxd\LetterboxdImportDiary->executeJob()
May 13 21:54:17 nixos movary[3443489]: #4 /app/src/Command/ProcessJobs.php(87): Movary\Service\JobProcessor->processJob()
May 13 21:54:17 nixos movary[3443489]: #5 /app/src/Command/ProcessJobs.php(50): Movary\Command\ProcessJobs->processJob()
May 13 21:54:17 nixos movary[3443489]: #6 /app/vendor/symfony/console/Command/Command.php(279): Movary\Command\ProcessJobs->execute()
May 13 21:54:17 nixos movary[3443489]: #7 /app/vendor/symfony/console/Application.php(1076): Symfony\Component\Console\Command\Command->run()
May 13 21:54:17 nixos movary[3443489]: #8 /app/vendor/symfony/console/Application.php(342): Symfony\Component\Console\Application->doRunCommand()
May 13 21:54:17 nixos movary[3443489]: #9 /app/vendor/symfony/console/Application.php(193): Symfony\Component\Console\Application->doRun()
May 13 21:54:17 nixos movary[3443489]: #10 /app/bin/console.php(33): Symfony\Component\Console\Application->run()
May 13 21:54:17 nixos movary[3443489]: #11 {main}
May 13 21:54:17 nixos movary[3443489]:   thrown in /app/src/ValueObject/Date.php on line 26
```