### PR TITLE
Build correct radarr API URL

### DIFF
--- a/src/HttpController/Web/RadarrController.php
+++ b/src/HttpController/Web/RadarrController.php
@@ -4,7 +4,7 @@ namespace Movary\HttpController\Web;
 
 use Movary\Domain\User\Service\Authentication;
 use Movary\Domain\User\UserApi;
-use Movary\Service\WebhookUrlBuilder;
+use Movary\Service\ServerSettings;
 use Movary\Util\Json;
 use Movary\ValueObject\Http\Response;
 
@@ -13,7 +13,7 @@ class RadarrController
     public function __construct(
         private readonly Authentication $authenticationService,
         private readonly UserApi $userApi,
-        private readonly WebhookUrlBuilder $webhookUrlBuilder,
+        private readonly ServerSettings $serverSettings,
     ) {
     }
 
@@ -27,7 +27,8 @@ class RadarrController
     public function regenerateRadarrFeedUrl() : Response
     {
         $feedId = $this->userApi->regenerateRadarrFeedId($this->authenticationService->getCurrentUserId());
+        $feedUrl = $this->serverSettings->getApplicationUrl() . '/api/feed/radarr/' . $feedId;
 
-        return Response::createJson(Json::encode(['url' => $this->webhookUrlBuilder->buildRadarrFeedUrl($feedId)]));
+        return Response::createJson(Json::encode(['url' => $feedUrl]));
     }
 }

--- a/src/HttpController/Web/SettingsController.php
+++ b/src/HttpController/Web/SettingsController.php
@@ -387,7 +387,7 @@ class SettingsController
         $applicationUrl = $this->serverSettings->getApplicationUrl();
 
         if ($applicationUrl !== null && $radarrFeedId !== null) {
-            $radarrFeedUrl = $this->webhookUrlBuilder->buildRadarrFeedUrl($radarrFeedId);
+            $radarrFeedUrl = $applicationUrl . '/api/feed/radarr/' . $radarrFeedId;
         }
 
         return Response::create(

--- a/src/Service/WebhookUrlBuilder.php
+++ b/src/Service/WebhookUrlBuilder.php
@@ -23,11 +23,6 @@ class WebhookUrlBuilder
         return $this->buildUrl('plex', $webhookId);
     }
 
-    public function buildRadarrFeedUrl(string $feedId) : ?string
-    {
-        return $this->buildUrl('api/feed/radarr', $feedId);
-    }
-
     private function buildUrl(string $webhookType, string $webhookId) : ?string
     {
         $applicationUrl = $this->serverSettings->getApplicationUrl();


### PR DESCRIPTION
The previous implementation was using the webhook URL builder, which was building an incorrect path: `/api/webhook/api/feed/radarr`.

The path should be `/api/feed/radarr`.

Let me know if you'd prefer a different implementation. Seeing as there's only two places the URL is build (the router and then in here), duplication seems fine. Building an abstraction for this URL seems overkill.