### PR TITLE
allow movie search by direct URL input

### DIFF
--- a/src/Api/Tmdb/TmdbApi.php
+++ b/src/Api/Tmdb/TmdbApi.php
@@ -51,6 +51,13 @@ class TmdbApi
         );
     }
 
+    /** searchID — directly exposes data in TMDB format to frontend given a TMDB ID */
+    public function searchID(int $movieId) : array
+    {
+        return $this->client->get('/movie/' . $movieId);
+    }
+
+    /** searchMovie — directly exposes data in TMDB format to frontend given a search query */
     public function searchMovie(string $searchTerm, ?Year $year = null, ?int $page = null) : array
     {
         $getParameters = ['query' => urlencode($searchTerm)];

--- a/src/HttpController/Web/NetflixController.php
+++ b/src/HttpController/Web/NetflixController.php
@@ -68,7 +68,17 @@ class NetflixController
     {
         $input = Json::decode($request->getBody());
 
-        $tmdbSearchResult = $this->tmdbApi->searchMovie($input['query']);
+        // direct input of TMDB URL
+        if (preg_match('#themoviedb.org/movie/(\\d+)($|-)#i', $input['query'], $tmdb_ids)) {
+            $tmdb_id = intval($tmdb_ids[1]);
+            $tmdbSearchResult = [
+                "results"=>[
+                    $this->tmdbApi->searchID($tmdb_id)
+                ]
+            ];
+        } else { // search as normal
+            $tmdbSearchResult = $this->tmdbApi->searchMovie($input['query']);
+        }
 
         return Response::createJson(Json::encode($tmdbSearchResult['results']));
     }

--- a/templates/component/modal-log-play.html.twig
+++ b/templates/component/modal-log-play.html.twig
@@ -11,7 +11,7 @@
                         <div class="input-group">
                             <input type="text"
                                    class="form-control"
-                                   placeholder="Search"
+                                   placeholder="Search or enter TMDB URL"
                                    value="{{ (searchTerm is null) ? '' : searchTerm }}"
                                    id="logPlayModalSearchInput"
                                    tabindex="0"
@@ -32,7 +32,7 @@
                             Something went wrong. Please try again.
                         </div>
                         <div class="alert alert-secondary d-none" role="alert" id="logPlayModalSearchNoResultAlert" style="margin-top: 1rem;margin-bottom: 0">
-                            No search results...
+                            No search results… try entering direct URL from <a href="https://www.themoviedb.org/">TMDB</a>?
                         </div>
                         <div class="text-center d-none" style="margin-top: 1rem;margin-bottom: 0" id="logPlayModalSearchSpinner">
                             <div class="spinner-border" role="status">


### PR DESCRIPTION
## CHANGES

- add note to search box

<img width="507" height="141" alt="image" src="https://github.com/user-attachments/assets/913f0d6b-d061-44b4-8708-cd3a03715735" />

- add note to "no results found..." result

<img width="508" height="217" alt="image" src="https://github.com/user-attachments/assets/264f6e10-d52d-45e3-8389-20cd25bd141c" />

- add `searchID` which mirrors `searchMovie`
- match TMDB URL on search and switch to `searchID` when matched

<img width="508" height="247" alt="image" src="https://github.com/user-attachments/assets/14697847-f243-427c-9534-9c0a3a17950f" />

## NOTES

thank you for creating #669 @leepeuker ;]… you know how to get someone interested

### skeleton

unfortunately, the skeleton you created was not used in the frontend search, which uses [`/settings/netflix/search`](https://github.com/alifeee/movary/blob/b570036913d97c167a6a2844cd9628acdc0d0b08/settings/routes.php#L145), and the code you were editing is used for [`/movies/search`](https://github.com/alifeee/movary/blob/b570036913d97c167a6a2844cd9628acdc0d0b08/settings/routes.php#L235). It seems to me that the former is used on the frontend, and the latter is used for the API.

### logging

I do not know how you normally debug your code. I ended up including the logger using 

```php
use Psr\Log\LoggerInterface;
…
private readonly LoggerInterface $logger,
…
$this->logger->debug('hey there palio');
```

you might have a better way of doing it, or even using xdebug :]

### development environment

this was very easy to set up :]… I effectively ran

```bash
cat << EONGINX > /etc/nginx/sites-available/movary.test
server {
	listen 80;
	listen [::]:80;
	server_name movary.test;
	location / {
		proxy_pass http://localhost:8053;
		proxy_redirect off;
		proxy_set_header Host $http_host;
		proxy_set_header X-Real-IP $remote_addr;
		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
		proxy_buffering off;
		proxy_buffer_size 16k;
		proxy_busy_buffers_size 24k;
		proxy_buffers 64 4k;
	}
}
EONGINX

echo '127.0.0.1	movary.test' | sudo tee -a /etc/hosts

export HTTP_PORT="8053"
export USER_ID="${UID}"
make build_development
make up_development
```

thanks for making something so easy to set up the dev environment of

### further edits

parts of this PR including:

- functions created
- methods
- wording

…you might have opinions of. I do not hold any of these sacred, and propose you change them if you want to :].

I did not necessarily uphold your practise of "doing everything in a very object-oriented way", and mostly just squished some code around to work. I am not highly excited about making factories and classes and objects, so can't say how much I'd be willing to edit this PR to fit with a more "OO" approach… it seems what code I made was similar to what was there already, but it did not look to be in the robust section… who's to say…
