### PR TITLE
add movie description to search results

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -206,7 +206,8 @@ function loadLogModalSearchResults(data) {
 
         backdropPath = item.backdrop_path != null ? 'https://image.tmdb.org/t/p/w780' + item.backdrop_path : null;
         posterPath = item.poster_path != null ? 'https://image.tmdb.org/t/p/w92' + item.poster_path : APPLICATION_URL + '/images/placeholder-image.png';
-        listElement.innerHTML = '<img src="' + posterPath + '" alt="Girl in a jacket" style="margin-right: .5rem;width: 3rem"><span>' + item.title + ' (' + releaseYear + ')</span>'
+        let truncated_description = item.overview != null ? item.overview.slice(0,100) + "…" : "N/A";
+        listElement.innerHTML = '<img src="' + posterPath + '" alt="Girl in a jacket" style="margin-right: .5rem;width: 3rem"><p style="margin:0;"><span><b>' + item.title + '</b> (' + releaseYear + ')</span><br><span style="opacity:0.75">' + truncated_description + '</span></p>'
 
         listElement.dataset.tmdbId = item.id
         listElement.dataset.poster = item.poster_path


### PR DESCRIPTION
a small change, as it seemed to make search results more clear

### before

which Closure is which? who is to say

<img width="513" height="900" alt="image" src="https://github.com/user-attachments/assets/0556ba9f-86ed-452f-98ea-f83991a6c393" />

### after

they have descriptions now. very nice

<img width="513" height="900" alt="image" src="https://github.com/user-attachments/assets/c8182364-d6ce-4d07-b447-55eed5503b7c" />

### notes

a few "magic numbers" were picked (i.e., descriptions truncated to 100 characters) — feel free to change/export these

everything (styles) is done in JS as there is no CSS stylesheet that is loaded on every page (but the "search box" is available on every page) — not being sure of the layout of the project, I am not sure a better way to do this (styling). maybe with bootstrap classes.
