### PR TITLE
Add xdebug support for development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,6 @@ TMDB_API_KEY=
 # HTTP_PORT_DOCS=8000
 
 # Xdebug - Used for debugging during development
-# XDEBUG_MODE=false
+# XDEBUG_MODE=off
 # XDEBUG_HOST=host.docker.internal
 # XDEBUG_PORT=9003

--- a/.env.example
+++ b/.env.example
@@ -78,3 +78,8 @@ TMDB_API_KEY=
 # Web ports on host the docker compose setup uses, restart containers on change
 # HTTP_PORT=80
 # HTTP_PORT_DOCS=8000
+
+# Xdebug - Used for debugging during development
+# XDEBUG_MODE=false
+# XDEBUG_HOST=host.docker.internal
+# XDEBUG_PORT=9003

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -71,7 +71,7 @@ RUN apk add --no-cache php84-pecl-xdebug
 ARG XDEBUG_INI="$PHP_INI_DIR/conf.d/xdebug.ini"
 RUN echo 'zend_extension=xdebug.so' > $XDEBUG_INI \
     && echo "[xdebug]" >> $XDEBUG_INI \
-    && echo "xdebug.mode=\${XDEBUG_MODE:-false}" >> $XDEBUG_INI \
+    && echo "xdebug.mode=\${XDEBUG_MODE:-off}" >> $XDEBUG_INI \
     && echo "xdebug.discover_client_host=true" >> $XDEBUG_INI \
     && echo "xdebug.start_with_request=yes" >> $XDEBUG_INI \
     && echo "xdebug.trigger_value=yes" >> $XDEBUG_INI \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -64,4 +64,22 @@ RUN composer install --no-dev
 
 FROM base AS development
 
+USER root
+
+RUN apk add --no-cache php84-pecl-xdebug
+
+ARG XDEBUG_INI="$PHP_INI_DIR/conf.d/xdebug.ini"
+RUN echo 'zend_extension=xdebug.so' > $XDEBUG_INI \
+    && echo "[xdebug]" >> $XDEBUG_INI \
+    && echo "xdebug.mode=\${XDEBUG_MODE:-false}" >> $XDEBUG_INI \
+    && echo "xdebug.discover_client_host=true" >> $XDEBUG_INI \
+    && echo "xdebug.start_with_request=yes" >> $XDEBUG_INI \
+    && echo "xdebug.trigger_value=yes" >> $XDEBUG_INI \
+    && echo "xdebug.log_level=0" >> $XDEBUG_INI \
+    && echo "xdebug.idekey=docker" >> $XDEBUG_INI \
+    && echo "xdebug.client_host=\${XDEBUG_HOST:-host.docker.internal}" >> $XDEBUG_INI \
+    && echo "xdebug.client_port=\${XDEBUG_PORT:-9003}" >> $XDEBUG_INI
+
+USER application
+
 RUN composer install

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -6,5 +6,7 @@ services:
       target: development
       args:
         - USER_ID=${USER_ID:-1000}
+    extra_hosts:
+      host.docker.internal: host-gateway
     volumes:
       - ./:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,7 @@ services:
       - "${HTTP_PORT:-80}:8080"
     environment:
       XDEBUG_MODE: "${XDEBUG_MODE:-false}"
+      XDEBUG_HOST: "${XDEBUG_HOST:-false}"
+      XDEBUG_PORT: "${XDEBUG_PORT:-false}"
       TMDB_API_KEY: "${TMDB_API_KEY:-XXXXX}"
       TMDB_ENABLE_IMAGE_CACHING: "${TMDB_ENABLE_IMAGE_CACHING:-0}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - "${HTTP_PORT:-80}:8080"
     environment:
-      XDEBUG_MODE: "${XDEBUG_MODE:-false}"
+      XDEBUG_MODE: "${XDEBUG_MODE:-off}"
       XDEBUG_HOST: "${XDEBUG_HOST:-host.docker.internal}"
       XDEBUG_PORT: "${XDEBUG_PORT:-9003}"
       TMDB_API_KEY: "${TMDB_API_KEY:-XXXXX}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,5 +9,6 @@ services:
     ports:
       - "${HTTP_PORT:-80}:8080"
     environment:
+      XDEBUG_MODE: "${XDEBUG_MODE:-false}"
       TMDB_API_KEY: "${TMDB_API_KEY:-XXXXX}"
       TMDB_ENABLE_IMAGE_CACHING: "${TMDB_ENABLE_IMAGE_CACHING:-0}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - "${HTTP_PORT:-80}:8080"
     environment:
       XDEBUG_MODE: "${XDEBUG_MODE:-false}"
-      XDEBUG_HOST: "${XDEBUG_HOST:-false}"
-      XDEBUG_PORT: "${XDEBUG_PORT:-false}"
+      XDEBUG_HOST: "${XDEBUG_HOST:-host.docker.internal}"
+      XDEBUG_PORT: "${XDEBUG_PORT:-9003}"
       TMDB_API_KEY: "${TMDB_API_KEY:-XXXXX}"
       TMDB_ENABLE_IMAGE_CACHING: "${TMDB_ENABLE_IMAGE_CACHING:-0}"

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -26,6 +26,29 @@ Use the following cli commands to manage your local environment:
 - `make app_database_migrate` execute the database migrations
 - `make app_jobs_process` process the next job from the queue (see database table `job_queue`)
 
+### Xdebug
+
+You can change `XDEBUG_MODE` to `debug` in the `.env` file to enable debugging using [Xdebug](https://xdebug.org/) in the development docker container.
+
+For example, in VSCode or VSCodium, the following debug configuration would allow you to set breakpoints and debug the PHP code:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Listen for Xdebug",
+      "type": "php",
+      "request": "launch",
+      "port": 9003,
+      "pathMappings": {
+        "/app": "${workspaceRoot}"
+      }
+    }
+  ]
+}
+```
+
 ### IDE recommendation: PhpStorm
 
 We recommend to use PhpStorm and to import the Movary code style scheme (found at `settings/phpstorm.xml`).


### PR DESCRIPTION
Changes:
- xdebug will be installed for the development docker image
- xdebug is disabled on default
- to enable xdebug set `XDEBUG_MODE=debug` in your `.env` file 
- additional `.env` options for xdebug:
  - `XDEBUG_HOST` (default: `host.docker.internal`)
  - `XDEBUG_PORT` (default: `9003`)