### PR TITLE
add TMDB link on movie search

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -248,11 +248,15 @@ async function selectLogModalTmdbItemForLogging(event) {
 
     document.getElementById('logPlayModalTitle').innerHTML = item.dataset.title + ' (' + item.dataset.releaseYear + ')'
     document.getElementById('logPlayModalTmdbIdInput').value = item.dataset.tmdbId
+    document.getElementById('logPlayModalFooterTMDBLink').setAttribute(
+        "href", "https://www.themoviedb.org/movie/" + item.dataset.tmdbId
+    )
 
     const rating = await fetchRating(item.dataset.tmdbId)
     setRatingStars('logPlayModal', rating)
 
     document.getElementById('logPlayModalWatchDateDiv').classList.remove('d-none')
+    document.getElementById('logPlayModalFooterTMDBLink').classList.remove('d-none')
     document.getElementById('logPlayModalFooterBackButton').classList.remove('d-none')
     document.getElementById('logPlayModalFooterWatchlistButton').classList.remove('d-none')
     document.getElementById('logPlayModalSearchDiv').classList.add('d-none')
@@ -361,6 +365,7 @@ async function showLogPlayModalWithSpecificMovie(tmdbId, movieTitle, releaseYear
     document.getElementById('logPlayModalSearchDiv').classList.add('d-none')
     document.getElementById('logPlayModalSearchResultList').classList.add('d-none')
     document.getElementById('logPlayModalFooter').classList.remove('d-none')
+    document.getElementById('logPlayModalFooterTMDBLink').classList.add('d-none')
     document.getElementById('logPlayModalFooterBackButton').classList.add('d-none')
     document.getElementById('logPlayModalFooterWatchlistButton').classList.add('d-none')
 

--- a/templates/component/modal-log-play.html.twig
+++ b/templates/component/modal-log-play.html.twig
@@ -92,6 +92,7 @@
                 </div>
                 <div class="modal-footer d-none" id="logPlayModalFooter">
                     <button type="submit" class="btn btn-secondary me-auto" onclick="backToLogModalSearchResults()" id="logPlayModalFooterBackButton">Back</button>
+                    <a id="logPlayModalFooterTMDBLink" style="display: flex; align-items: center;cursor:pointer;margin-right: 0.3rem;text-align: center" href="" target="_blank"><img src="{{ applicationUrl }}/images/tmdb-logo.svg" style="width: 2rem" alt="tmdb logo"></a>
                     <button type="submit" class="btn btn-primary" onclick="addToWatchlist('logPlayModal')" id="logPlayModalFooterWatchlistButton">Add to watchlist</button>
                     <button type="submit" class="btn btn-primary" onclick="logMovie('logPlayModal')">Add play</button>
                 </div>


### PR DESCRIPTION
on the movie search, it would be nice to see "more info" about a movie without adding it to your watchlist or recording a play.

<img width="563" height="340" alt="image" src="https://github.com/user-attachments/assets/53a612da-09da-4eb1-9a4e-7aa93e49fe15" />

It seems fruitless to import each movie into Movary like this, so I suggest adding a TMDB link. I've copied the one from the movie page (this one)

<img width="259" height="141" alt="image" src="https://github.com/user-attachments/assets/3a6aa85e-5e74-4e23-ba4f-64a3aceb34dd" />

## before

<img width="521" height="371" alt="image" src="https://github.com/user-attachments/assets/300b8e4f-043d-487d-b331-b979675eb5a0" />

## after

<img width="521" height="371" alt="image" src="https://github.com/user-attachments/assets/950e279f-13d1-4496-b595-bd8bfe7d4265" />

I believe I've got the JavaScript hiding and showing done correctly (e.g., TMDB logo link has the `href` updated on new movie selected, and is hidden if the modal is opened from an individual movie page – as that page already has a TMDB link)

p.s., I am assuming from the history of the issue that #572 is semi-abandoned, so I am happy to continue making front-end changes (I think it works just fine with PHP)