### PR TITLE
Add "on watchlist" notifier

### DIFF
--- a/templates/page/movie.html.twig
+++ b/templates/page/movie.html.twig
@@ -23,6 +23,12 @@
         <input type="hidden" id="movieId" value="{{ movie.id }}">
         <input type="hidden" id="username" value="{{ routeUsername }}">
 
+        {% if isOnWatchlist %}
+        <span>
+            on <a href="{{ applicationUrl }}/users/{{ routeUsername ?: currentUserName }}/watchlist">watchlist</a>
+        </span>
+        {%endif%}
+
         <div class="fw-light" id="ratingStars"
              style="color: rgb(255, 193, 7);font-size: 1.5rem;margin-bottom: 0.5rem;cursor: default">
             <span id="ratingStarsSpan">


### PR DESCRIPTION
this is broken out from #678

add a (simple) notifier to show if a film is on a user's watchlist

<img width="337" height="210" alt="image" src="https://github.com/user-attachments/assets/f77a4c6e-275d-4c40-aa0d-278fd5460abd" />

## why

### button not obvious

in my opinion, the presence of an "add" or "remove" button is not the same as being shown the state of something (whether a film is on your watchlist)

<img width="258" height="146" alt="image" src="https://github.com/user-attachments/assets/28949fa6-5ecc-476d-ab9e-3ceed4c862ca" />

### button not visible publically

secondly, the "add to watchlist"/"remove from watchlist" button is not visible when looking at a public profile not logged in as that user, so a different way of showing if a film was on the watchlist would be good for public viewers

<img width="371" height="566" alt="image" src="https://github.com/user-attachments/assets/dcde5bfd-7b54-4a7a-96a6-3d6ba0cb1a2d" />

## design

the design is very simple as I wanted to gauge whether this would be a useful feature first. if it is, then I can work on a better design to make it suit the page more.