### PR TITLE
add `object-fit-cover h-100` to all movie poster images

### DIFF
--- a/templates/component/dashboard/row-last-plays-cinema.html.twig
+++ b/templates/component/dashboard/row-last-plays-cinema.html.twig
@@ -10,7 +10,7 @@
                     <a class="card h-100" style="cursor: pointer" href="{{ applicationUrl }}/users/{{ routeUsername }}/movies/{{ lastPlay.id }}-{{ lastPlay.title|slugify }}">
                         <div style="height: 100%">
                             <img src="{{ lastPlay.poster_path }}"
-                                 class="card-img-top"
+                                 class="card-img-top object-fit-cover h-100"
                                  alt="{{ lastPlay.title }} Poster">
 
                         </div>

--- a/templates/component/dashboard/row-last-plays.html.twig
+++ b/templates/component/dashboard/row-last-plays.html.twig
@@ -10,7 +10,7 @@
                     <a class="card h-100" style="cursor: pointer" href="{{ applicationUrl }}/users/{{ routeUsername }}/movies/{{ lastPlay.id }}-{{ lastPlay.title|slugify }}">
                         <div style="height: 100%">
                             <img src="{{ lastPlay.poster_path }}"
-                                 class="card-img-top"
+                                 class="card-img-top object-fit-cover h-100"
                                  alt="{{ lastPlay.title }} Poster">
 
                         </div>

--- a/templates/component/dashboard/row-watchlist.html.twig
+++ b/templates/component/dashboard/row-watchlist.html.twig
@@ -12,7 +12,7 @@
                         <input id="watchlistTitle_{{ watchlistItem.id }}" value="{{ watchlistItem.title }}" type="hidden">
                         <div style="height: 100%">
                             <img src="{{ watchlistItem.poster_path }}"
-                                 class="card-img-top"
+                                 class="card-img-top object-fit-cover h-100"
                                  alt="{{ watchlistItem.title }} Poster">
 
                         </div>

--- a/templates/page/history.html.twig
+++ b/templates/page/history.html.twig
@@ -25,7 +25,7 @@
                 {% for historyEntry in historyEntries %}
                     <div class="col" style="padding-bottom: 1rem;">
                         <a class="card h-100 position-relative" style="cursor: pointer" href="{{ applicationUrl }}/users/{{ routeUsername }}/movies/{{ historyEntry.id }}-{{ historyEntry.title|slugify }}">
-                            <img src="{{ historyEntry.poster_path }}" class="card-img-top" alt="{{ historyEntry.title }} Poster">
+                            <img src="{{ historyEntry.poster_path }}" class="card-img-top object-fit-cover h-100" alt="{{ historyEntry.title }} Poster">
                             <div class="card-footer" style="padding: 0.1rem">
                                 <small class="text-muted" style="font-size: 0.8rem">{{ historyEntry.watched_at|date(dateFormatPhp) }}</small>
                             </div>

--- a/templates/page/movies.html.twig
+++ b/templates/page/movies.html.twig
@@ -32,7 +32,7 @@
                 {% for movie in movies %}
                     <div class="col" style="padding-bottom: 1rem;">
                         <a class="card h-100 position-relative" style="cursor: pointer" href="{{ applicationUrl }}/users/{{ routeUsername }}/movies/{{ movie.id }}-{{ movie.title|slugify }}">
-                            <img src="{{ movie.poster_path }}" class="card-img-top card-img-bottom" alt="{{ movie.title }} Poster">
+                            <img src="{{ movie.poster_path }}" class="card-img-top card-img-bottom object-fit-cover h-100" alt="{{ movie.title }} Poster">
 
                             {% if movie.userRating is not null %}
                                 <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-warning text-dark" style="font-size: 0.8rem">

--- a/templates/page/watchlist.html.twig
+++ b/templates/page/watchlist.html.twig
@@ -39,7 +39,7 @@
                             style="cursor: pointer; position: relative;"
                             id="card-{{ watchlistEntry.id }}"
                         >
-                            <img data-movieId="{{ watchlistEntry.id }}" src="{{ watchlistEntry.poster_path }}" class="card-img-top card-img-bottom" alt="{{ watchlistEntry.title }} Poster">
+                            <img data-movieId="{{ watchlistEntry.id }}" src="{{ watchlistEntry.poster_path }}" class="card-img-top card-img-bottom object-fit-cover h-100" alt="{{ watchlistEntry.title }} Poster">
                        </a>
                     </div>
                 {% endfor %}


### PR DESCRIPTION
sometimes there was a blank bit at the bottom if the TMDB image is sized incorrectly (not tall enough)

## before

<img width="1318" height="413" alt="image" src="https://github.com/user-attachments/assets/e6fb8184-4f7c-4d0c-9594-989a7d486dcf" />

## after

<img width="1318" height="413" alt="image" src="https://github.com/user-attachments/assets/bd7738f2-6536-4917-bce5-810ebf212bfd" />

## before

<img width="444" height="344" alt="image" src="https://github.com/user-attachments/assets/e6c3ffc5-36b0-404c-a690-f2b70d68671d" />

## after

<img width="444" height="344" alt="image" src="https://github.com/user-attachments/assets/361742e2-17c9-45da-91de-ef2be8694718" />
