### PR TITLE
remove trailing slash in all requests (issue redirect)

### DIFF
--- a/build/config/conf.d/default.conf
+++ b/build/config/conf.d/default.conf
@@ -11,6 +11,8 @@ server {
     index index.php;
 
     location / {
+        # remove trailing slash in all requests (issue redirect)
+        rewrite ^(.+)/+$ $1 permanent;
         # First attempt to serve request as file, then
         # as directory, then fall back to index.php
         try_files $uri $uri/ /index.php$is_args$args;


### PR DESCRIPTION
pulled out from https://github.com/leepeuker/movary/pull/697#issuecomment-3299115974

motivation is that with the change of #697, a trailing slash might be left in the URL when editing it (e.g., when going from `/<user>/history` to `/<user>/` (bad) instead of `/<user>` (good)) — just makes it easier on the user ;]

before

```bash
$ curl -I http://movary.test/users/alifeee/dashboard/
HTTP/1.1 404 Not Found
```

after

```bash
$ curl -I http://movary.test/users/alifeee/dashboard/
HTTP/1.1 301 Moved Permanently
Location: /users/alifeee/dashboard
```