### PR TITLE
wrap `if` statement body in `{` `}`

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -270,10 +270,11 @@ async function selectLogModalTmdbItemForLogging(event) {
     // icons indicating watched/on watchlist, linking to movary page if it exists (which it should)
     let isWatchedEl = item.dataset.isWatched ? '<i class="bi bi-eye-fill" data-bs-toggle="tooltip" data-bs-title="Watched"></i>' : ''
     let isOnWatchlistEl = item.dataset.isOnWatchlist ? '<i class="bi bi-bookmark-fill" data-bs-toggle="tooltip" data-bs-title="On Watchlist"></i>' : ''
-    if (item.dataset.movaryId)
+    if (item.dataset.movaryId) {
         movaryUrl = APPLICATION_URL + "/users/" + document.getElementById('currentUserName').value + "/movies/" + item.dataset.movaryId
         isWatchedEl = '<a href="' + movaryUrl + '">' + isWatchedEl + '</a>';
         isOnWatchlistEl = '<a href="' + movaryUrl + '">' + isOnWatchlistEl + '</a>';
+    }
         
     document.getElementById("logPlayModalTitle").innerHTML = item.dataset.title + " (" + item.dataset.releaseYear + ")" + isWatchedEl + isOnWatchlistEl;
     document.querySelectorAll("#logPlayModalTitle i.bi").forEach(tooltipTriggerEl => {


### PR DESCRIPTION
you can't currently click these on the `main` branch

<img width="417" height="251" alt="image" src="https://github.com/user-attachments/assets/3972bf28-1804-4550-97e5-97a92e86ccb8" />

because of uncaught errors

<img width="606" height="158" alt="image" src="https://github.com/user-attachments/assets/66e90583-c7e7-45fc-ad9f-2c1fb1189250" />

this PR fixes that. I did not catch the error as code was indented, as I do not have my formatter enabled, as it would change the entire file.
