### PR TITLE
fix searching by TMDB URL

### DIFF
--- a/src/HttpController/Api/MovieSearchController.php
+++ b/src/HttpController/Api/MovieSearchController.php
@@ -33,7 +33,12 @@ class MovieSearchController
             $requestData->getPage(),
         );
 
-        $totalResults = (int)$tmdbResponse['total_results'];
+        // total_results doesn't exist when you enter direct TMDB URLs
+        if (key_exists('total_results', $tmdbResponse)) {
+            $totalResults = (int)$tmdbResponse['total_results'];
+        } else {
+            $totalResults = count($tmdbResponse['results']);
+        }
         if ($totalResults === 0) {
             return Response::createJson(
                 Json::encode([
@@ -44,7 +49,12 @@ class MovieSearchController
             );
         }
 
-        $limit = (int)floor($totalResults / (int)$tmdbResponse['total_pages']);
+        // total_pages doesn't exist when you enter direct TMDB URLs
+        if (key_exists('total_pages', $tmdbResponse)) {
+            $limit = (int)floor($totalResults / (int)$tmdbResponse['total_pages']);
+        } else {
+            $limit = $totalResults;
+        }
 
         $paginationElements = $this->paginationElementsCalculator->createPaginationElements(
             $totalResults,


### PR DESCRIPTION
closes https://github.com/leepeuker/movary/issues/763

add fallback for when `total_results` and `total_pages` don't exist when searching direct TMDB URLs

see https://github.com/leepeuker/movary/issues/763#issuecomment-4757222111

for @leepeuker to look at … simple change really.

TEST: I can see a test file called `movie-search.http`, but I can't see how it's triggered. It would be good to add another search test for TMDB URLs, but I can't see how this would be done